### PR TITLE
Implement PublicScratchpadTool MCP tool (#7)

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -152,6 +152,8 @@ pub async fn run_server(ant_tp_config: AntTpConfig) -> io::Result<()> {
         public_data_service_data.clone(),
         pointer_service_data.clone(),
         register_service_data.clone(),
+        graph_service_data.clone(),
+        scratchpad_service_data.clone(),
         evm_wallet_data.clone()
     );
     let mcp_tool_service = StreamableHttpService::builder()

--- a/src/service/scratchpad_service.rs
+++ b/src/service/scratchpad_service.rs
@@ -33,6 +33,7 @@ impl Scratchpad {
     }
 }
 
+#[derive(Debug)]
 pub struct ScratchpadService {
     caching_client: CachingClient,
     ant_tp_config: AntTpConfig,

--- a/src/tool/mod.rs
+++ b/src/tool/mod.rs
@@ -4,6 +4,8 @@ use crate::service::public_data_service::PublicDataService;
 use crate::service::pnr_service::PnrService;
 use crate::service::pointer_service::PointerService;
 use crate::service::register_service::RegisterService;
+use crate::service::graph_service::GraphService;
+use crate::service::scratchpad_service::ScratchpadService;
 use actix_web::web::Data;
 use ant_evm::EvmWallet;
 use rmcp::handler::server::tool::ToolRouter;
@@ -17,6 +19,8 @@ use rmcp::{tool_handler, ServerHandler};
     pub mod public_data_tool;
     pub mod pointer_tool;
     pub mod register_tool;
+    pub mod graph_tool;
+    pub mod public_scratchpad_tool;
 
     #[derive(Debug, Clone)]
     pub struct McpTool {
@@ -26,6 +30,8 @@ use rmcp::{tool_handler, ServerHandler};
         public_data_service: Data<PublicDataService>,
         pointer_service: Data<PointerService>,
         register_service: Data<RegisterService>,
+        graph_service: Data<GraphService>,
+        scratchpad_service: Data<ScratchpadService>,
         evm_wallet: Data<EvmWallet>,
         tool_router: ToolRouter<Self>,
     }
@@ -38,6 +44,8 @@ use rmcp::{tool_handler, ServerHandler};
             public_data_service: Data<PublicDataService>,
             pointer_service: Data<PointerService>,
             register_service: Data<RegisterService>,
+            graph_service: Data<GraphService>,
+            scratchpad_service: Data<ScratchpadService>,
             evm_wallet: Data<EvmWallet>
         ) -> Self {
             Self {
@@ -47,6 +55,8 @@ use rmcp::{tool_handler, ServerHandler};
                 public_data_service,
                 pointer_service,
                 register_service,
+                graph_service,
+                scratchpad_service,
                 evm_wallet,
                 tool_router: Self::chunk_tool_router()
                     + Self::pnr_tool_router()
@@ -54,6 +64,8 @@ use rmcp::{tool_handler, ServerHandler};
                     + Self::public_data_tool_router()
                     + Self::pointer_tool_router()
                     + Self::register_tool_router()
+                    + Self::graph_tool_router()
+                    + Self::public_scratchpad_tool_router()
             }
         }
     }

--- a/src/tool/public_scratchpad_tool.rs
+++ b/src/tool/public_scratchpad_tool.rs
@@ -1,0 +1,138 @@
+#![allow(dead_code)]
+
+use rmcp::{handler::server::{
+    wrapper::Parameters,
+}, schemars, tool, tool_router, ErrorData};
+use rmcp::model::{CallToolResult, ErrorCode};
+use rmcp::schemars::JsonSchema;
+use serde::Deserialize;
+use serde_json::json;
+use crate::controller::StoreType;
+use crate::error::scratchpad_error::ScratchpadError;
+use crate::service::scratchpad_service::Scratchpad;
+use crate::tool::McpTool;
+
+#[derive(Debug, Deserialize, JsonSchema)]
+struct CreatePublicScratchpadRequest {
+    #[schemars(description = "Name of the public scratchpad")]
+    name: String,
+    #[schemars(description = "Base64 encoded content of the scratchpad")]
+    content: String,
+    #[schemars(description = "Store scratchpad on memory, disk or network")]
+    store_type: String,
+}
+
+#[derive(Debug, Deserialize, JsonSchema)]
+struct UpdatePublicScratchpadRequest {
+    #[schemars(description = "Address of the public scratchpad")]
+    address: String,
+    #[schemars(description = "Name of the public scratchpad")]
+    name: String,
+    #[schemars(description = "Base64 encoded content of the scratchpad")]
+    content: String,
+    #[schemars(description = "Store scratchpad on memory, disk or network")]
+    store_type: String,
+}
+
+#[derive(Debug, Deserialize, JsonSchema)]
+struct GetPublicScratchpadRequest {
+    #[schemars(description = "Address of the public scratchpad")]
+    address: String,
+}
+
+impl From<Scratchpad> for CallToolResult {
+    fn from(scratchpad: Scratchpad) -> CallToolResult {
+        CallToolResult::structured(json!(scratchpad))
+    }
+}
+
+impl From<ScratchpadError> for ErrorData {
+    fn from(scratchpad_error: ScratchpadError) -> Self {
+        ErrorData::new(ErrorCode::INTERNAL_ERROR, scratchpad_error.to_string(), None)
+    }
+}
+
+#[tool_router(router = public_scratchpad_tool_router, vis = "pub")]
+impl McpTool {
+
+    #[tool(description = "Create a new public scratchpad")]
+    async fn create_public_scratchpad(
+        &self,
+        Parameters(CreatePublicScratchpadRequest { name, content, store_type }): Parameters<CreatePublicScratchpadRequest>,
+    ) -> Result<CallToolResult, ErrorData> {
+        let scratchpad = Scratchpad::new(None, None, None, None, Some(content), None);
+        Ok(self.scratchpad_service.create_scratchpad(
+            name,
+            scratchpad,
+            self.evm_wallet.get_ref().clone(),
+            false,
+            StoreType::from(store_type)
+        ).await?.into())
+    }
+
+    #[tool(description = "Update an existing public scratchpad")]
+    async fn update_public_scratchpad(
+        &self,
+        Parameters(UpdatePublicScratchpadRequest { address, name, content, store_type }): Parameters<UpdatePublicScratchpadRequest>,
+    ) -> Result<CallToolResult, ErrorData> {
+        let scratchpad = Scratchpad::new(None, None, None, None, Some(content), None);
+        Ok(self.scratchpad_service.update_scratchpad(
+            address,
+            name,
+            scratchpad,
+            self.evm_wallet.get_ref().clone(),
+            false,
+            StoreType::from(store_type)
+        ).await?.into())
+    }
+
+    #[tool(description = "Get a public scratchpad by its address")]
+    async fn get_public_scratchpad(
+        &self,
+        Parameters(GetPublicScratchpadRequest { address }): Parameters<GetPublicScratchpadRequest>,
+    ) -> Result<CallToolResult, ErrorData> {
+        Ok(self.scratchpad_service.get_scratchpad(address, None, false).await?.into())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[tokio::test]
+    async fn test_create_public_scratchpad_request_serialization() {
+        let json = r#"{
+            "name": "test_scratchpad",
+            "content": "SGVsbG8gd29ybGQ=",
+            "store_type": "memory"
+        }"#;
+        let request: CreatePublicScratchpadRequest = serde_json::from_str(json).unwrap();
+        assert_eq!(request.name, "test_scratchpad");
+        assert_eq!(request.content, "SGVsbG8gd29ybGQ=");
+        assert_eq!(request.store_type, "memory");
+    }
+
+    #[tokio::test]
+    async fn test_update_public_scratchpad_request_serialization() {
+        let json = r#"{
+            "address": "0x123",
+            "name": "test_scratchpad",
+            "content": "SGVsbG8gd29ybGQ=",
+            "store_type": "memory"
+        }"#;
+        let request: UpdatePublicScratchpadRequest = serde_json::from_str(json).unwrap();
+        assert_eq!(request.address, "0x123");
+        assert_eq!(request.name, "test_scratchpad");
+        assert_eq!(request.content, "SGVsbG8gd29ybGQ=");
+        assert_eq!(request.store_type, "memory");
+    }
+
+    #[tokio::test]
+    async fn test_get_public_scratchpad_request_serialization() {
+        let json = r#"{
+            "address": "0x123"
+        }"#;
+        let request: GetPublicScratchpadRequest = serde_json::from_str(json).unwrap();
+        assert_eq!(request.address, "0x123");
+    }
+}


### PR DESCRIPTION
Resolves #7.

This PR implements the `PublicScratchpadTool` as an MCP tool, allowing users to create, update, and retrieve public scratchpads via the MCP interface.

### Changes:
- **`src/service/scratchpad_service.rs`**: Added `#[derive(Debug)]` to `ScratchpadService`.
- **`src/tool/mod.rs`**: Integrated `ScratchpadService` into `McpTool` and registered the `public_scratchpad_tool` router.
- **`src/lib.rs`**: Updated `McpTool` initialization.
- **`src/tool/public_scratchpad_tool.rs`**: Implemented the MCP tool endpoints and added unit tests for request serialization.