### PR TITLE
Create gRPC service handler for register operations

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -1,4 +1,5 @@
 fn main() -> Result<(), Box<dyn std::error::Error>> {
     tonic_build::compile_protos("proto/pointer.proto")?;
+    tonic_build::compile_protos("proto/register.proto")?;
     Ok(())
 }

--- a/proto/register.proto
+++ b/proto/register.proto
@@ -1,0 +1,43 @@
+syntax = "proto3";
+
+package register;
+
+service RegisterService {
+  rpc CreateRegister(CreateRegisterRequest) returns (RegisterResponse);
+  rpc UpdateRegister(UpdateRegisterRequest) returns (RegisterResponse);
+  rpc GetRegister(GetRegisterRequest) returns (RegisterResponse);
+  rpc GetRegisterHistory(GetRegisterHistoryRequest) returns (RegisterHistoryResponse);
+}
+
+message Register {
+  optional string name = 1;
+  string content = 2;
+  optional string address = 3;
+}
+
+message CreateRegisterRequest {
+  Register register = 1;
+  optional string cache_only = 2;
+}
+
+message UpdateRegisterRequest {
+  string address = 1;
+  Register register = 2;
+  optional string cache_only = 3;
+}
+
+message GetRegisterRequest {
+  string address = 1;
+}
+
+message GetRegisterHistoryRequest {
+  string address = 1;
+}
+
+message RegisterResponse {
+  Register register = 1;
+}
+
+message RegisterHistoryResponse {
+  repeated Register registers = 1;
+}

--- a/src/grpc/mod.rs
+++ b/src/grpc/mod.rs
@@ -1,1 +1,2 @@
 pub mod pointer_handler;
+pub mod register_handler;

--- a/src/grpc/register_handler.rs
+++ b/src/grpc/register_handler.rs
@@ -1,0 +1,153 @@
+use tonic::{Request, Response, Status};
+use actix_web::web::Data;
+use ant_evm::EvmWallet;
+use crate::service::register_service::{Register as ServiceRegister, RegisterService};
+use crate::controller::StoreType;
+
+pub mod register_proto {
+    tonic::include_proto!("register");
+}
+
+use register_proto::register_service_server::RegisterService as RegisterServiceTrait;
+pub use register_proto::register_service_server::RegisterServiceServer;
+use register_proto::{Register, RegisterResponse, RegisterHistoryResponse, CreateRegisterRequest, UpdateRegisterRequest, GetRegisterRequest, GetRegisterHistoryRequest};
+use crate::error::register_error::RegisterError;
+
+pub struct RegisterHandler {
+    register_service: Data<RegisterService>,
+    evm_wallet: Data<EvmWallet>,
+}
+
+impl RegisterHandler {
+    pub fn new(register_service: Data<RegisterService>, evm_wallet: Data<EvmWallet>) -> Self {
+        Self { register_service, evm_wallet }
+    }
+}
+
+impl From<Register> for ServiceRegister {
+    fn from(r: Register) -> Self {
+        ServiceRegister::new(r.name, r.content, r.address)
+    }
+}
+
+impl From<ServiceRegister> for Register {
+    fn from(r: ServiceRegister) -> Self {
+        Register {
+            name: r.name,
+            content: r.content,
+            address: r.address,
+        }
+    }
+}
+
+impl From<RegisterError> for Status {
+    fn from(register_error: RegisterError) -> Self {
+        Status::internal(register_error.to_string())
+    }
+}
+
+#[tonic::async_trait]
+impl RegisterServiceTrait for RegisterHandler {
+    async fn create_register(
+        &self,
+        request: Request<CreateRegisterRequest>,
+    ) -> Result<Response<RegisterResponse>, Status> {
+        let req = request.into_inner();
+        let register = req.register.ok_or_else(|| Status::invalid_argument("Register is required"))?;
+
+        let result = self.register_service.create_register(
+            ServiceRegister::from(register),
+            self.evm_wallet.get_ref().clone(),
+            StoreType::from(req.cache_only.unwrap_or_default()),
+        ).await?;
+
+        Ok(Response::new(RegisterResponse {
+            register: Some(Register::from(result)),
+        }))
+    }
+
+    async fn update_register(
+        &self,
+        request: Request<UpdateRegisterRequest>,
+    ) -> Result<Response<RegisterResponse>, Status> {
+        let req = request.into_inner();
+        let register = req.register.ok_or_else(|| Status::invalid_argument("Register is required"))?;
+
+        let result = self.register_service.update_register(
+            req.address,
+            ServiceRegister::from(register),
+            self.evm_wallet.get_ref().clone(),
+            StoreType::from(req.cache_only.unwrap_or_default()),
+        ).await?;
+
+        Ok(Response::new(RegisterResponse {
+            register: Some(Register::from(result)),
+        }))
+    }
+
+    async fn get_register(
+        &self,
+        request: Request<GetRegisterRequest>,
+    ) -> Result<Response<RegisterResponse>, Status> {
+        let req = request.into_inner();
+        let result = self.register_service.get_register(req.address).await?;
+
+        Ok(Response::new(RegisterResponse {
+            register: Some(Register::from(result)),
+        }))
+    }
+
+    async fn get_register_history(
+        &self,
+        request: Request<GetRegisterHistoryRequest>,
+    ) -> Result<Response<RegisterHistoryResponse>, Status> {
+        let req = request.into_inner();
+        let result = self.register_service.get_register_history(req.address).await?;
+
+        Ok(Response::new(RegisterHistoryResponse {
+            registers: result.into_iter().map(Register::from).collect(),
+        }))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::service::register_service::Register;
+    use crate::error::register_error::RegisterError;
+    use crate::error::GetError;
+
+    #[test]
+    fn test_from_register_proto_to_service() {
+        let proto_register = Register {
+            name: Some("test".to_string()),
+            content: "content".to_string(),
+            address: Some("address".to_string()),
+        };
+        let service_register = ServiceRegister::from(proto_register.clone());
+        assert_eq!(service_register.name, proto_register.name);
+        assert_eq!(service_register.content, proto_register.content);
+        assert_eq!(service_register.address, proto_register.address);
+    }
+
+    #[test]
+    fn test_from_service_to_register_proto() {
+        let service_register = ServiceRegister::new(
+            Some("test".to_string()),
+            "content".to_string(),
+            Some("address".to_string()),
+        );
+        let proto_register = Register::from(service_register.clone());
+        assert_eq!(proto_register.name, service_register.name);
+        assert_eq!(proto_register.content, service_register.content);
+        assert_eq!(proto_register.address, service_register.address);
+    }
+
+    #[test]
+    fn test_status_from_register_error() {
+        let error = RegisterError::GetError(GetError::RecordNotFound("not found".to_string()));
+        let status: Status = error.into();
+        assert_eq!(status.code(), tonic::Code::Internal);
+        assert!(status.message().contains("not found"));
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -56,6 +56,7 @@ use crate::service::resolver_service::ResolverService;
 use crate::service::scratchpad_service::ScratchpadService;
 use crate::tool::McpTool;
 use crate::grpc::pointer_handler::{PointerHandler, PointerServiceServer};
+use crate::grpc::register_handler::{RegisterHandler, RegisterServiceServer};
 
 static ACTIX_SERVER_HANDLE: Lazy<Mutex<Option<ServerHandle>>> = Lazy::new(|| Mutex::new(None));
 static TONIC_SERVER_HANDLE: Lazy<Mutex<Option<String>>> = Lazy::new(|| Mutex::new(None));
@@ -170,10 +171,12 @@ pub async fn run_server(ant_tp_config: AntTpConfig) -> io::Result<()> {
 
     // GRPC
     let pointer_handler = PointerHandler::new(pointer_service_data.clone(), evm_wallet_data.clone());
+    let register_handler = RegisterHandler::new(register_service_data.clone(), evm_wallet_data.clone());
     let tonic_server = async move {
         tokio::task::spawn(
             Server::builder()
                 .add_service(PointerServiceServer::new(pointer_handler))
+                .add_service(RegisterServiceServer::new(register_handler))
                 .serve(grpc_listen_address),
         )
     };

--- a/src/service/register_service.rs
+++ b/src/service/register_service.rs
@@ -11,12 +11,12 @@ use crate::controller::StoreType;
 use crate::error::register_error::RegisterError;
 use crate::service::resolver_service::ResolverService;
 
-#[derive(Serialize, Deserialize, ToSchema)]
+#[derive(Serialize, Deserialize, ToSchema, Clone, Debug)]
 pub struct Register {
-    name: Option<String>,
-    content: String,
+    pub name: Option<String>,
+    pub content: String,
     #[schema(read_only)]
-    address: Option<String>,
+    pub address: Option<String>,
 }
 
 impl Register {


### PR DESCRIPTION
Resolves #15

This PR adds a gRPC service handler for register operations, mirroring the existing `register_controller.rs` and following the pattern of `pointer_handler.rs`.

Changes:
- Created `proto/register.proto` with `RegisterService` definition.
- Updated `build.rs` to compile the new proto file.
- Created `src/grpc/register_handler.rs` implementing the gRPC service.
- Integrated the new handler into `src/lib.rs`.
- Made `Register` struct in `register_service.rs` public and implemented `Clone` and `Debug` for better integration and testing.
- Added unit tests for `RegisterHandler`.