### PR TITLE
Create gRPC service handler for PNR operations (#22)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1186,7 +1186,7 @@ dependencies = [
 
 [[package]]
 name = "anttp"
-version = "0.23.1"
+version = "0.23.2"
 dependencies = [
  "actix-files",
  "actix-http",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "anttp"
-version = "0.23.1"
+version = "0.23.2"
 edition = "2024"
 authors = ["Paul Green"]
 description = "AntTP is an HTTP server for the Autonomi Network"

--- a/build.rs
+++ b/build.rs
@@ -4,5 +4,6 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     tonic_build::compile_protos("proto/chunk.proto")?;
     tonic_build::compile_protos("proto/graph.proto")?;
     tonic_build::compile_protos("proto/command.proto")?;
+    tonic_build::compile_protos("proto/pnr.proto")?;
     Ok(())
 }

--- a/proto/pnr.proto
+++ b/proto/pnr.proto
@@ -1,0 +1,35 @@
+syntax = "proto3";
+
+package pnr;
+
+service PnrService {
+  rpc CreatePnr(CreatePnrRequest) returns (PnrResponse);
+}
+
+message PnrZone {
+  string name = 1;
+  repeated PnrRecord records = 2;
+  optional string resolver_address = 3;
+  optional string personal_address = 4;
+}
+
+message PnrRecord {
+  optional string sub_name = 1;
+  string address = 2;
+  PnrRecordType record_type = 3;
+  uint64 ttl = 4;
+}
+
+enum PnrRecordType {
+  A = 0;
+  X = 1;
+}
+
+message CreatePnrRequest {
+  PnrZone pnr_zone = 1;
+  optional string cache_only = 2;
+}
+
+message PnrResponse {
+  PnrZone pnr_zone = 1;
+}

--- a/src/grpc/mod.rs
+++ b/src/grpc/mod.rs
@@ -3,3 +3,4 @@ pub mod register_handler;
 pub mod chunk_handler;
 pub mod graph_handler;
 pub mod command_handler;
+pub mod pnr_handler;

--- a/src/grpc/pnr_handler.rs
+++ b/src/grpc/pnr_handler.rs
@@ -1,0 +1,150 @@
+use tonic::{Request, Response, Status};
+use actix_web::web::Data;
+use ant_evm::EvmWallet;
+use crate::service::pnr_service::PnrService;
+use crate::controller::StoreType;
+use crate::model::pnr::{PnrZone as ServicePnrZone, PnrRecord as ServicePnrRecord, PnrRecordType as ServicePnrRecordType};
+
+pub mod pnr_proto {
+    tonic::include_proto!("pnr");
+}
+
+use pnr_proto::pnr_service_server::PnrService as PnrServiceTrait;
+pub use pnr_proto::pnr_service_server::PnrServiceServer;
+use pnr_proto::{PnrZone, PnrRecord, PnrRecordType, PnrResponse, CreatePnrRequest};
+
+pub struct PnrHandler {
+    pnr_service: Data<PnrService>,
+    evm_wallet: Data<EvmWallet>,
+}
+
+impl PnrHandler {
+    pub fn new(pnr_service: Data<PnrService>, evm_wallet: Data<EvmWallet>) -> Self {
+        Self { pnr_service, evm_wallet }
+    }
+}
+
+impl From<PnrRecordType> for ServicePnrRecordType {
+    fn from(t: PnrRecordType) -> Self {
+        match t {
+            PnrRecordType::A => ServicePnrRecordType::A,
+            PnrRecordType::X => ServicePnrRecordType::X,
+        }
+    }
+}
+
+impl From<ServicePnrRecordType> for PnrRecordType {
+    fn from(t: ServicePnrRecordType) -> Self {
+        match t {
+            ServicePnrRecordType::A => PnrRecordType::A,
+            ServicePnrRecordType::X => PnrRecordType::X,
+        }
+    }
+}
+
+impl From<PnrRecord> for ServicePnrRecord {
+    fn from(r: PnrRecord) -> Self {
+        ServicePnrRecord {
+            sub_name: r.sub_name,
+            address: r.address,
+            record_type: ServicePnrRecordType::from(PnrRecordType::try_from(r.record_type).unwrap_or(PnrRecordType::A)),
+            ttl: r.ttl,
+        }
+    }
+}
+
+impl From<ServicePnrRecord> for PnrRecord {
+    fn from(r: ServicePnrRecord) -> Self {
+        PnrRecord {
+            sub_name: r.sub_name,
+            address: r.address,
+            record_type: PnrRecordType::from(r.record_type) as i32,
+            ttl: r.ttl,
+        }
+    }
+}
+
+impl From<PnrZone> for ServicePnrZone {
+    fn from(z: PnrZone) -> Self {
+        ServicePnrZone {
+            name: z.name,
+            records: z.records.into_iter().map(ServicePnrRecord::from).collect(),
+            resolver_address: z.resolver_address,
+            personal_address: z.personal_address,
+        }
+    }
+}
+
+impl From<ServicePnrZone> for PnrZone {
+    fn from(z: ServicePnrZone) -> Self {
+        PnrZone {
+            name: z.name,
+            records: z.records.into_iter().map(PnrRecord::from).collect(),
+            resolver_address: z.resolver_address,
+            personal_address: z.personal_address,
+        }
+    }
+}
+
+// Status mapping is already defined in pointer_handler.rs
+// impl From<PointerError> for Status { ... }
+
+#[tonic::async_trait]
+impl PnrServiceTrait for PnrHandler {
+    async fn create_pnr(
+        &self,
+        request: Request<CreatePnrRequest>,
+    ) -> Result<Response<PnrResponse>, Status> {
+        let req = request.into_inner();
+        let pnr_zone = req.pnr_zone.ok_or_else(|| Status::invalid_argument("PnrZone is required"))?;
+
+        let result = self.pnr_service.create_pnr(
+            ServicePnrZone::from(pnr_zone),
+            self.evm_wallet.get_ref().clone(),
+            StoreType::from(req.cache_only.unwrap_or_default()),
+        ).await?;
+
+        Ok(Response::new(PnrResponse {
+            pnr_zone: Some(PnrZone::from(result)),
+        }))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::model::pnr::{PnrZone as ServicePnrZone, PnrRecord as ServicePnrRecord, PnrRecordType as ServicePnrRecordType};
+
+    #[tokio::test]
+    async fn test_create_pnr() {
+        // This is a unit test for the handler. In a real scenario, we might want to mock the PnrService.
+        // However, the issue asks for unit tests where applicable.
+        // Given the complexity of mocking in this codebase without a dedicated mock framework,
+        // we will at least test the mapping logic.
+        
+        let proto_record = PnrRecord {
+            sub_name: Some("www".to_string()),
+            address: "address1".to_string(),
+            record_type: PnrRecordType::A as i32,
+            ttl: 3600,
+        };
+        
+        let service_record = ServicePnrRecord::from(proto_record.clone());
+        assert_eq!(service_record.sub_name, proto_record.sub_name);
+        assert_eq!(service_record.address, proto_record.address);
+        assert!(matches!(service_record.record_type, ServicePnrRecordType::A));
+        assert_eq!(service_record.ttl, proto_record.ttl);
+        
+        let proto_zone = PnrZone {
+            name: "example.com".to_string(),
+            records: vec![proto_record],
+            resolver_address: None,
+            personal_address: None,
+        };
+        
+        let service_zone = ServicePnrZone::from(proto_zone.clone());
+        assert_eq!(service_zone.name, proto_zone.name);
+        assert_eq!(service_zone.records.len(), 1);
+        assert_eq!(service_zone.records[0].address, "address1");
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -60,6 +60,7 @@ use crate::grpc::register_handler::{RegisterHandler, RegisterServiceServer};
 use crate::grpc::chunk_handler::{ChunkHandler, ChunkServiceServer};
 use crate::grpc::graph_handler::{GraphHandler, GraphServiceServer};
 use crate::grpc::command_handler::{CommandHandler, CommandServiceServer};
+use crate::grpc::pnr_handler::{PnrHandler, PnrServiceServer};
 
 static ACTIX_SERVER_HANDLE: Lazy<Mutex<Option<ServerHandle>>> = Lazy::new(|| Mutex::new(None));
 static TONIC_SERVER_HANDLE: Lazy<Mutex<Option<String>>> = Lazy::new(|| Mutex::new(None));
@@ -178,6 +179,7 @@ pub async fn run_server(ant_tp_config: AntTpConfig) -> io::Result<()> {
     let chunk_handler = ChunkHandler::new(chunk_service_data.clone(), evm_wallet_data.clone());
     let graph_handler = GraphHandler::new(graph_service_data.clone(), evm_wallet_data.clone());
     let command_handler = CommandHandler::new(command_service_data.clone());
+    let pnr_handler = PnrHandler::new(pnr_service_data.clone(), evm_wallet_data.clone());
     let tonic_server = async move {
         tokio::task::spawn(
             Server::builder()
@@ -186,6 +188,7 @@ pub async fn run_server(ant_tp_config: AntTpConfig) -> io::Result<()> {
                 .add_service(ChunkServiceServer::new(chunk_handler))
                 .add_service(GraphServiceServer::new(graph_handler))
                 .add_service(CommandServiceServer::new(command_handler))
+                .add_service(PnrServiceServer::new(pnr_handler))
                 .serve(grpc_listen_address),
         )
     };


### PR DESCRIPTION
Resolves issue #22.

Added a gRPC service handler for PNR (Pointer Name Resolver) operations.

Changes:
- Created `proto/pnr.proto` with the PNR service and message definitions.
- Implemented `src/grpc/pnr_handler.rs` including:
    - gRPC service implementation for `CreatePnr`.
    - `From` traits for mapping between Protobuf messages and internal service models.
    - Unit tests for the mapping logic.
- Registered the new handler in `src/grpc/mod.rs` and `src/lib.rs`.
- Updated `build.rs` to compile the new Protobuf file.
- Incremented the patch version in `Cargo.toml`.