### PR TITLE
Issue #27: Create gRPC service handler for Public Archive operations

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1186,7 +1186,7 @@ dependencies = [
 
 [[package]]
 name = "anttp"
-version = "0.23.3"
+version = "0.23.4"
 dependencies = [
  "actix-files",
  "actix-http",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "anttp"
-version = "0.23.3"
+version = "0.23.4"
 edition = "2024"
 authors = ["Paul Green"]
 description = "AntTP is an HTTP server for the Autonomi Network"

--- a/build.rs
+++ b/build.rs
@@ -6,5 +6,6 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     tonic_build::compile_protos("proto/command.proto")?;
     tonic_build::compile_protos("proto/pnr.proto")?;
     tonic_build::compile_protos("proto/public_data.proto")?;
+    tonic_build::compile_protos("proto/public_archive.proto")?;
     Ok(())
 }

--- a/proto/public_archive.proto
+++ b/proto/public_archive.proto
@@ -1,0 +1,28 @@
+syntax = "proto3";
+
+package public_archive;
+
+service PublicArchiveService {
+  rpc CreatePublicArchive(CreatePublicArchiveRequest) returns (PublicArchiveResponse);
+  rpc UpdatePublicArchive(UpdatePublicArchiveRequest) returns (PublicArchiveResponse);
+}
+
+message File {
+  string name = 1;
+  bytes content = 2;
+}
+
+message CreatePublicArchiveRequest {
+  repeated File files = 1;
+  optional string cache_only = 2;
+}
+
+message UpdatePublicArchiveRequest {
+  string address = 1;
+  repeated File files = 2;
+  optional string cache_only = 3;
+}
+
+message PublicArchiveResponse {
+  optional string address = 1;
+}

--- a/src/grpc/mod.rs
+++ b/src/grpc/mod.rs
@@ -5,3 +5,4 @@ pub mod graph_handler;
 pub mod command_handler;
 pub mod pnr_handler;
 pub mod public_data_handler;
+pub mod public_archive_handler;

--- a/src/grpc/public_archive_handler.rs
+++ b/src/grpc/public_archive_handler.rs
@@ -1,0 +1,112 @@
+use tonic::{Request, Response, Status};
+use actix_web::web::Data;
+use ant_evm::EvmWallet;
+use actix_multipart::form::tempfile::TempFile;
+use actix_multipart::form::MultipartForm;
+use std::io::Write;
+use crate::service::public_archive_service::{PublicArchiveForm, PublicArchiveService, Upload};
+use crate::controller::StoreType;
+use crate::error::public_archive_error::PublicArchiveError;
+
+pub mod public_archive_proto {
+    tonic::include_proto!("public_archive");
+}
+
+use public_archive_proto::public_archive_service_server::PublicArchiveService as PublicArchiveServiceTrait;
+pub use public_archive_proto::public_archive_service_server::PublicArchiveServiceServer;
+use public_archive_proto::{CreatePublicArchiveRequest, UpdatePublicArchiveRequest, PublicArchiveResponse, File as ProtoFile};
+
+pub struct PublicArchiveHandler {
+    public_archive_service: Data<PublicArchiveService>,
+    evm_wallet: Data<EvmWallet>,
+}
+
+impl PublicArchiveHandler {
+    pub fn new(public_archive_service: Data<PublicArchiveService>, evm_wallet: Data<EvmWallet>) -> Self {
+        Self { public_archive_service, evm_wallet }
+    }
+
+    fn map_to_multipart_form(&self, files: Vec<ProtoFile>) -> Result<MultipartForm<PublicArchiveForm>, Status> {
+        let mut temp_files = Vec::new();
+        for file in files {
+            let mut temp_file = tempfile::NamedTempFile::new().map_err(|e|
+                Status::internal(format!("Failed to create temp file: {}", e))
+            )?;
+            temp_file.write_all(&file.content).map_err(|e|
+                Status::internal(format!("Failed to write to temp file: {}", e))
+            )?;
+
+            temp_files.push(TempFile {
+                file: temp_file,
+                file_name: Some(file.name),
+                content_type: None,
+                size: file.content.len(),
+            });
+        }
+        Ok(MultipartForm(PublicArchiveForm { files: temp_files }))
+    }
+}
+
+impl From<Upload> for PublicArchiveResponse {
+    fn from(upload: Upload) -> Self {
+        PublicArchiveResponse {
+            address: upload.address,
+        }
+    }
+}
+
+impl From<PublicArchiveError> for Status {
+    fn from(error: PublicArchiveError) -> Self {
+        Status::internal(error.to_string())
+    }
+}
+
+#[tonic::async_trait]
+impl PublicArchiveServiceTrait for PublicArchiveHandler {
+    async fn create_public_archive(
+        &self,
+        request: Request<CreatePublicArchiveRequest>,
+    ) -> Result<Response<PublicArchiveResponse>, Status> {
+        let req = request.into_inner();
+        let public_archive_form = self.map_to_multipart_form(req.files)?;
+        
+        let result = self.public_archive_service.create_public_archive(
+            public_archive_form,
+            self.evm_wallet.get_ref().clone(),
+            StoreType::from(req.cache_only.unwrap_or_default())
+        ).await?;
+
+        Ok(Response::new(PublicArchiveResponse::from(result)))
+    }
+
+    async fn update_public_archive(
+        &self,
+        request: Request<UpdatePublicArchiveRequest>,
+    ) -> Result<Response<PublicArchiveResponse>, Status> {
+        let req = request.into_inner();
+        let public_archive_form = self.map_to_multipart_form(req.files)?;
+        
+        let result = self.public_archive_service.update_public_archive(
+            req.address,
+            public_archive_form,
+            self.evm_wallet.get_ref().clone(),
+            StoreType::from(req.cache_only.unwrap_or_default())
+        ).await?;
+
+        Ok(Response::new(PublicArchiveResponse::from(result)))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[tokio::test]
+    async fn test_mapping() {
+        let upload = Upload {
+            address: Some("0x1234".to_string()),
+        };
+        let response = PublicArchiveResponse::from(upload);
+        assert_eq!(response.address, Some("0x1234".to_string()));
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -62,6 +62,7 @@ use crate::grpc::graph_handler::{GraphHandler, GraphServiceServer};
 use crate::grpc::command_handler::{CommandHandler, CommandServiceServer};
 use crate::grpc::pnr_handler::{PnrHandler, PnrServiceServer};
 use crate::grpc::public_data_handler::{PublicDataHandler, PublicServiceServer};
+use crate::grpc::public_archive_handler::{PublicArchiveHandler, PublicArchiveServiceServer};
 
 static ACTIX_SERVER_HANDLE: Lazy<Mutex<Option<ServerHandle>>> = Lazy::new(|| Mutex::new(None));
 static TONIC_SERVER_HANDLE: Lazy<Mutex<Option<String>>> = Lazy::new(|| Mutex::new(None));
@@ -182,6 +183,7 @@ pub async fn run_server(ant_tp_config: AntTpConfig) -> io::Result<()> {
     let command_handler = CommandHandler::new(command_service_data.clone());
     let pnr_handler = PnrHandler::new(pnr_service_data.clone(), evm_wallet_data.clone());
     let public_data_handler = PublicDataHandler::new(public_data_service_data.clone(), evm_wallet_data.clone());
+    let public_archive_handler = PublicArchiveHandler::new(public_archive_service_data.clone(), evm_wallet_data.clone());
     let tonic_server = async move {
         tokio::task::spawn(
             Server::builder()
@@ -192,6 +194,7 @@ pub async fn run_server(ant_tp_config: AntTpConfig) -> io::Result<()> {
                 .add_service(CommandServiceServer::new(command_handler))
                 .add_service(PnrServiceServer::new(pnr_handler))
                 .add_service(PublicServiceServer::new(public_data_handler))
+                .add_service(PublicArchiveServiceServer::new(public_archive_handler))
                 .serve(grpc_listen_address),
         )
     };

--- a/src/service/public_archive_service.rs
+++ b/src/service/public_archive_service.rs
@@ -31,7 +31,7 @@ use crate::model::archive::Archive;
 #[derive(Serialize, Deserialize, Clone, ToSchema)]
 pub struct Upload {
     #[schema(read_only)]
-    address: Option<String>,
+    pub address: Option<String>,
 }
 
 #[derive(Debug, MultipartForm, ToSchema)]


### PR DESCRIPTION
Resolves #27

This PR adds a gRPC service handler for Public Archive operations, allowing third-party gRPC clients to create and update public archives.

Key changes:
- Created `proto/public_archive.proto` with `PublicArchiveService` definition.
- Implemented `src/grpc/public_archive_handler.rs` with `CreatePublicArchive` and `UpdatePublicArchive` rpcs.
- Integrated the new handler into `src/lib.rs` and the Tonic server.
- Implemented `map_to_multipart_form` for gRPC File types to interface with `PublicArchiveService`.
- Made `Upload.address` public to allow mapping to gRPC response.
- Updated `Cargo.toml` version to `0.23.4`.
- Added unit tests for the handler mapping.