### PR TITLE
Create gRPC service handler for Public Scratchpad operations

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1186,7 +1186,7 @@ dependencies = [
 
 [[package]]
 name = "anttp"
-version = "0.23.4"
+version = "0.23.5"
 dependencies = [
  "actix-files",
  "actix-http",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "anttp"
-version = "0.23.4"
+version = "0.23.5"
 edition = "2024"
 authors = ["Paul Green"]
 description = "AntTP is an HTTP server for the Autonomi Network"

--- a/build.rs
+++ b/build.rs
@@ -7,5 +7,6 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     tonic_build::compile_protos("proto/pnr.proto")?;
     tonic_build::compile_protos("proto/public_data.proto")?;
     tonic_build::compile_protos("proto/public_archive.proto")?;
+    tonic_build::compile_protos("proto/public_scratchpad.proto")?;
     Ok(())
 }

--- a/proto/public_scratchpad.proto
+++ b/proto/public_scratchpad.proto
@@ -1,0 +1,39 @@
+syntax = "proto3";
+
+package public_scratchpad;
+
+service PublicScratchpadService {
+  rpc CreatePublicScratchpad (CreatePublicScratchpadRequest) returns (PublicScratchpadResponse);
+  rpc UpdatePublicScratchpad (UpdatePublicScratchpadRequest) returns (PublicScratchpadResponse);
+  rpc GetPublicScratchpad (GetPublicScratchpadRequest) returns (PublicScratchpadResponse);
+}
+
+message PublicScratchpad {
+  optional string name = 1;
+  optional string address = 2;
+  optional uint64 data_encoding = 3;
+  optional string signature = 4;
+  optional string content = 5;
+  optional uint64 counter = 6;
+}
+
+message CreatePublicScratchpadRequest {
+  string name = 1;
+  PublicScratchpad scratchpad = 2;
+  optional string cache_only = 3;
+}
+
+message UpdatePublicScratchpadRequest {
+  string address = 1;
+  string name = 2;
+  PublicScratchpad scratchpad = 3;
+  optional string cache_only = 4;
+}
+
+message GetPublicScratchpadRequest {
+  string address = 1;
+}
+
+message PublicScratchpadResponse {
+  PublicScratchpad scratchpad = 1;
+}

--- a/src/grpc/mod.rs
+++ b/src/grpc/mod.rs
@@ -6,3 +6,4 @@ pub mod command_handler;
 pub mod pnr_handler;
 pub mod public_data_handler;
 pub mod public_archive_handler;
+pub mod public_scratchpad_handler;

--- a/src/grpc/public_scratchpad_handler.rs
+++ b/src/grpc/public_scratchpad_handler.rs
@@ -1,0 +1,156 @@
+use tonic::{Request, Response, Status};
+use actix_web::web::Data;
+use ant_evm::EvmWallet;
+use crate::service::scratchpad_service::{Scratchpad as ServiceScratchpad, ScratchpadService};
+use crate::controller::StoreType;
+use crate::error::scratchpad_error::ScratchpadError;
+
+pub mod public_scratchpad_proto {
+    tonic::include_proto!("public_scratchpad");
+}
+
+use public_scratchpad_proto::public_scratchpad_service_server::PublicScratchpadService as PublicScratchpadServiceTrait;
+pub use public_scratchpad_proto::public_scratchpad_service_server::PublicScratchpadServiceServer;
+use public_scratchpad_proto::{PublicScratchpad, PublicScratchpadResponse, CreatePublicScratchpadRequest, UpdatePublicScratchpadRequest, GetPublicScratchpadRequest};
+
+pub struct PublicScratchpadHandler {
+    scratchpad_service: Data<ScratchpadService>,
+    evm_wallet: Data<EvmWallet>,
+}
+
+impl PublicScratchpadHandler {
+    pub fn new(scratchpad_service: Data<ScratchpadService>, evm_wallet: Data<EvmWallet>) -> Self {
+        Self { scratchpad_service, evm_wallet }
+    }
+}
+
+impl From<PublicScratchpad> for ServiceScratchpad {
+    fn from(p: PublicScratchpad) -> Self {
+        ServiceScratchpad::new(
+            p.name,
+            p.address,
+            p.data_encoding,
+            p.signature,
+            p.content,
+            p.counter,
+        )
+    }
+}
+
+impl From<ServiceScratchpad> for PublicScratchpad {
+    fn from(p: ServiceScratchpad) -> Self {
+        PublicScratchpad {
+            name: p.name(),
+            address: p.address(),
+            data_encoding: p.data_encoding(),
+            signature: p.signature(),
+            content: p.content(),
+            counter: p.counter(),
+        }
+    }
+}
+
+impl From<ScratchpadError> for Status {
+    fn from(error: ScratchpadError) -> Self {
+        Status::internal(error.to_string())
+    }
+}
+
+#[tonic::async_trait]
+impl PublicScratchpadServiceTrait for PublicScratchpadHandler {
+    async fn create_public_scratchpad(
+        &self,
+        request: Request<CreatePublicScratchpadRequest>,
+    ) -> Result<Response<PublicScratchpadResponse>, Status> {
+        let req = request.into_inner();
+        let scratchpad = req.scratchpad.ok_or_else(|| Status::invalid_argument("Scratchpad is required"))?;
+
+        let result = self.scratchpad_service.create_scratchpad(
+            req.name,
+            ServiceScratchpad::from(scratchpad),
+            self.evm_wallet.get_ref().clone(),
+            false,
+            StoreType::from(req.cache_only.unwrap_or_default()),
+        ).await?;
+
+        Ok(Response::new(PublicScratchpadResponse {
+            scratchpad: Some(PublicScratchpad::from(result)),
+        }))
+    }
+
+    async fn update_public_scratchpad(
+        &self,
+        request: Request<UpdatePublicScratchpadRequest>,
+    ) -> Result<Response<PublicScratchpadResponse>, Status> {
+        let req = request.into_inner();
+        let scratchpad = req.scratchpad.ok_or_else(|| Status::invalid_argument("Scratchpad is required"))?;
+
+        let result = self.scratchpad_service.update_scratchpad(
+            req.address,
+            req.name,
+            ServiceScratchpad::from(scratchpad),
+            self.evm_wallet.get_ref().clone(),
+            false,
+            StoreType::from(req.cache_only.unwrap_or_default()),
+        ).await?;
+
+        Ok(Response::new(PublicScratchpadResponse {
+            scratchpad: Some(PublicScratchpad::from(result)),
+        }))
+    }
+
+    async fn get_public_scratchpad(
+        &self,
+        request: Request<GetPublicScratchpadRequest>,
+    ) -> Result<Response<PublicScratchpadResponse>, Status> {
+        let req = request.into_inner();
+        let result = self.scratchpad_service.get_scratchpad(req.address, None, false).await?;
+
+        Ok(Response::new(PublicScratchpadResponse {
+            scratchpad: Some(PublicScratchpad::from(result)),
+        }))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[tokio::test]
+    async fn test_from_proto_scratchpad() {
+        let proto = PublicScratchpad {
+            name: Some("test".to_string()),
+            address: Some("0x123".to_string()),
+            data_encoding: Some(1),
+            signature: Some("sig".to_string()),
+            content: Some("cont".to_string()),
+            counter: Some(2),
+        };
+        let service: ServiceScratchpad = proto.clone().into();
+        assert_eq!(service.name(), proto.name);
+        assert_eq!(service.address(), proto.address);
+        assert_eq!(service.data_encoding(), proto.data_encoding);
+        assert_eq!(service.signature(), proto.signature);
+        assert_eq!(service.content(), proto.content);
+        assert_eq!(service.counter(), proto.counter);
+    }
+
+    #[tokio::test]
+    async fn test_to_proto_scratchpad() {
+        let service = ServiceScratchpad::new(
+            Some("test".to_string()),
+            Some("0x123".to_string()),
+            Some(1),
+            Some("sig".to_string()),
+            Some("cont".to_string()),
+            Some(2),
+        );
+        let proto: PublicScratchpad = service.into();
+        assert_eq!(proto.name, Some("test".to_string()));
+        assert_eq!(proto.address, Some("0x123".to_string()));
+        assert_eq!(proto.data_encoding, Some(1));
+        assert_eq!(proto.signature, Some("sig".to_string()));
+        assert_eq!(proto.content, Some("cont".to_string()));
+        assert_eq!(proto.counter, Some(2));
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -63,6 +63,7 @@ use crate::grpc::command_handler::{CommandHandler, CommandServiceServer};
 use crate::grpc::pnr_handler::{PnrHandler, PnrServiceServer};
 use crate::grpc::public_data_handler::{PublicDataHandler, PublicServiceServer};
 use crate::grpc::public_archive_handler::{PublicArchiveHandler, PublicArchiveServiceServer};
+use crate::grpc::public_scratchpad_handler::{PublicScratchpadHandler, PublicScratchpadServiceServer};
 
 static ACTIX_SERVER_HANDLE: Lazy<Mutex<Option<ServerHandle>>> = Lazy::new(|| Mutex::new(None));
 static TONIC_SERVER_HANDLE: Lazy<Mutex<Option<String>>> = Lazy::new(|| Mutex::new(None));
@@ -184,6 +185,7 @@ pub async fn run_server(ant_tp_config: AntTpConfig) -> io::Result<()> {
     let pnr_handler = PnrHandler::new(pnr_service_data.clone(), evm_wallet_data.clone());
     let public_data_handler = PublicDataHandler::new(public_data_service_data.clone(), evm_wallet_data.clone());
     let public_archive_handler = PublicArchiveHandler::new(public_archive_service_data.clone(), evm_wallet_data.clone());
+    let public_scratchpad_handler = PublicScratchpadHandler::new(scratchpad_service_data.clone(), evm_wallet_data.clone());
     let tonic_server = async move {
         tokio::task::spawn(
             Server::builder()
@@ -195,6 +197,7 @@ pub async fn run_server(ant_tp_config: AntTpConfig) -> io::Result<()> {
                 .add_service(PnrServiceServer::new(pnr_handler))
                 .add_service(PublicServiceServer::new(public_data_handler))
                 .add_service(PublicArchiveServiceServer::new(public_archive_handler))
+                .add_service(PublicScratchpadServiceServer::new(public_scratchpad_handler))
                 .serve(grpc_listen_address),
         )
     };

--- a/src/service/scratchpad_service.rs
+++ b/src/service/scratchpad_service.rs
@@ -31,6 +31,30 @@ impl Scratchpad {
     pub fn new(name: Option<String>, address: Option<String>, data_encoding: Option<u64>, signature: Option<String>, content: Option<String>, counter: Option<u64>) -> Self {
         Scratchpad { name, address, data_encoding, signature, content, counter }
     }
+
+    pub fn name(&self) -> Option<String> {
+        self.name.clone()
+    }
+
+    pub fn address(&self) -> Option<String> {
+        self.address.clone()
+    }
+
+    pub fn data_encoding(&self) -> Option<u64> {
+        self.data_encoding
+    }
+
+    pub fn signature(&self) -> Option<String> {
+        self.signature.clone()
+    }
+
+    pub fn content(&self) -> Option<String> {
+        self.content.clone()
+    }
+
+    pub fn counter(&self) -> Option<u64> {
+        self.counter
+    }
 }
 
 #[derive(Debug)]


### PR DESCRIPTION
Resolves #29

Implemented gRPC service handler for Public Scratchpad operations.

Changes:
- Created `proto/public_scratchpad.proto` defining the service and messages.
- Updated `build.rs` to compile the new proto file.
- Added getters to `Scratchpad` struct in `src/service/scratchpad_service.rs`.
- Created `src/grpc/public_scratchpad_handler.rs` implementing `PublicScratchpadService`.
- Registered `PublicScratchpadHandler` in `src/lib.rs`.
- Incremented patch version in `Cargo.toml`.
- Added unit tests for mapping between gRPC and service types.