### PR TITLE
Add support for Tarchives over REST interface (#35)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1186,7 +1186,7 @@ dependencies = [
 
 [[package]]
 name = "anttp"
-version = "0.23.6"
+version = "0.23.7"
 dependencies = [
  "actix-files",
  "actix-http",
@@ -1226,6 +1226,7 @@ dependencies = [
  "serde",
  "serde_json",
  "sha2",
+ "tar",
  "tempfile",
  "thiserror 2.0.17",
  "tokio",
@@ -3125,6 +3126,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "filetime"
+version = "0.2.27"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f98844151eee8917efc50bd9e8318cb963ae8b297431495d3f758616ea5c57db"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "libredox",
+]
+
+[[package]]
 name = "find-msvc-tools"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4799,6 +4811,7 @@ checksum = "391290121bad3d37fbddad76d8f5d1c1c314cfc646d143d7e07a3086ddff0ce3"
 dependencies = [
  "bitflags 2.9.4",
  "libc",
+ "redox_syscall",
 ]
 
 [[package]]
@@ -7245,6 +7258,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "55937e1799185b12863d447f42597ed69d9928686b8d88a1df17376a097d8369"
 
 [[package]]
+name = "tar"
+version = "0.4.44"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d863878d212c87a19c1a610eb53bb01fe12951c0501cf5a0d65f724914a667a"
+dependencies = [
+ "filetime",
+ "libc",
+ "xattr",
+]
+
+[[package]]
 name = "tempfile"
 version = "3.21.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -8602,6 +8626,16 @@ dependencies = [
  "rusticata-macros",
  "thiserror 2.0.17",
  "time",
+]
+
+[[package]]
+name = "xattr"
+version = "1.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32e45ad4206f6d2479085147f02bc2ef834ac85886624a23575ae137c8aa8156"
+dependencies = [
+ "libc",
+ "rustix 1.1.1",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "anttp"
-version = "0.23.6"
+version = "0.23.7"
 edition = "2024"
 authors = ["Paul Green"]
 description = "AntTP is an HTTP server for the Autonomi Network"
@@ -45,6 +45,7 @@ once_cell = "1.21"
 foyer = "0.19"
 async-trait = "0.1"
 sanitize-filename = "0.6"
+tar = "0.4"
 sha2 = "0.10"
 indexmap = "2.11"
 rand = "0.9"

--- a/src/controller/mod.rs
+++ b/src/controller/mod.rs
@@ -4,6 +4,7 @@ pub mod pointer_controller;
 pub mod register_controller;
 pub mod file_controller;
 pub mod public_archive_controller;
+pub mod tarchive_controller;
 pub mod private_scratchpad_controller;
 pub mod public_scratchpad_controller;
 pub mod chunk_controller;

--- a/src/controller/tarchive_controller.rs
+++ b/src/controller/tarchive_controller.rs
@@ -1,0 +1,70 @@
+use actix_multipart::form::MultipartForm;
+use actix_web::{web, HttpRequest, HttpResponse};
+use actix_web::web::Data;
+use ant_evm::EvmWallet;
+use log::debug;
+use crate::service::public_archive_service::{PublicArchiveForm, Upload};
+use crate::service::tarchive_service::TarchiveService;
+use crate::error::tarchive_error::TarchiveError;
+use crate::controller::get_store_type;
+
+#[utoipa::path(
+    post,
+    path = "/anttp-0/multipart/tarchive",
+    request_body(
+        content = PublicArchiveForm,
+        content_type = "multipart/form-data"
+    ),
+    responses(
+        (status = CREATED, description = "Tarchive created successfully", body = Upload)
+    ),
+    params(
+        ("x-cache-only", Header, description = "Only persist to cache and do not publish (memory|disk|none)",
+        example = "memory"),
+    ),
+)]
+pub async fn post_tarchive(
+    public_archive_form: MultipartForm<PublicArchiveForm>,
+    tarchive_service: Data<TarchiveService>,
+    evm_wallet_data: Data<EvmWallet>,
+    request: HttpRequest
+) -> Result<HttpResponse, TarchiveError> {
+    let evm_wallet = evm_wallet_data.get_ref().clone();
+
+    debug!("Creating new tarchive from multipart POST");
+    Ok(HttpResponse::Created().json(
+        tarchive_service.create_tarchive(public_archive_form, evm_wallet, get_store_type(&request)).await?
+    ))
+}
+
+#[utoipa::path(
+    put,
+    path = "/anttp-0/multipart/tarchive/{address}",
+    request_body(
+        content = PublicArchiveForm,
+        content_type = "multipart/form-data"
+    ),
+    responses(
+        (status = OK, description = "Tarchive updated successfully", body = Upload)
+    ),
+    params(
+        ("address" = String, Path, description = "Tarchive address"),
+        ("x-cache-only", Header, description = "Only persist to cache and do not publish (memory|disk|none)",
+        example = "memory"),
+    ),
+)]
+pub async fn put_tarchive(
+    path: web::Path<String>,
+    public_archive_form: MultipartForm<PublicArchiveForm>,
+    tarchive_service: Data<TarchiveService>,
+    evm_wallet_data: Data<EvmWallet>,
+    request: HttpRequest,
+) -> Result<HttpResponse, TarchiveError> {
+    let address = path.into_inner();
+    let evm_wallet = evm_wallet_data.get_ref().clone();
+
+    debug!("Updating [{}] tarchive from multipart PUT with store type [{:?}]", address, get_store_type(&request));
+    Ok(HttpResponse::Ok().json(
+        tarchive_service.update_tarchive(address, public_archive_form, evm_wallet, get_store_type(&request)).await?
+    ))
+}

--- a/src/error/mod.rs
+++ b/src/error/mod.rs
@@ -16,6 +16,7 @@ pub mod chunk_error;
 pub mod graph_error;
 pub mod pointer_error;
 pub mod public_archive_error;
+pub mod tarchive_error;
 pub mod public_data_error;
 pub mod register_error;
 pub mod scratchpad_error;

--- a/src/error/tarchive_error.rs
+++ b/src/error/tarchive_error.rs
@@ -1,0 +1,81 @@
+use std::io;
+use thiserror::Error;
+use serde::Serialize;
+use actix_http::StatusCode;
+use actix_web::HttpResponse;
+use actix_web::http::header::ContentType;
+use autonomi::AddressParseError;
+use autonomi::client::ConnectError;
+use crate::error::{CreateError, GetError, UpdateError};
+use crate::error::public_data_error::PublicDataError;
+
+#[derive(Error, Debug, Serialize)]
+pub enum TarchiveError {
+    #[error("create error: {0}")]
+    CreateError(CreateError),
+    #[error("update error: {0}")]
+    UpdateError(UpdateError),
+    #[error("get error: {0}")]
+    GetError(GetError),
+}
+
+impl From<CreateError> for TarchiveError {
+    fn from(value: CreateError) -> Self {
+        Self::CreateError(value)
+    }
+}
+
+impl From<GetError> for TarchiveError {
+    fn from(value: GetError) -> Self {
+        Self::GetError(value)
+    }
+}
+
+impl From<UpdateError> for TarchiveError {
+    fn from(value: UpdateError) -> Self {
+        Self::UpdateError(value)
+    }
+}
+
+impl From<PublicDataError> for TarchiveError {
+    fn from(value: PublicDataError) -> Self {
+        match value {
+            PublicDataError::CreateError(e) => Self::CreateError(e),
+            PublicDataError::GetError(e) => Self::GetError(e),
+        }
+    }
+}
+
+impl From<ConnectError> for TarchiveError {
+    fn from(value: ConnectError) -> Self {
+        Self::GetError(value.into())
+    }
+}
+
+impl From<io::Error> for TarchiveError {
+    fn from(value: io::Error) -> Self {
+        Self::UpdateError(value.into())
+    }
+}
+
+impl From<AddressParseError> for TarchiveError {
+    fn from(value: AddressParseError) -> Self {
+        Self::GetError(value.into())
+    }
+}
+
+impl actix_web::ResponseError for TarchiveError {
+    fn status_code(&self) -> StatusCode {
+        match self {
+            TarchiveError::GetError(v) => v.status_code(),
+            TarchiveError::CreateError(v) => v.status_code(),
+            TarchiveError::UpdateError(v) => v.status_code(),
+        }
+    }
+
+    fn error_response(&self) -> HttpResponse {
+        HttpResponse::build(self.status_code())
+            .insert_header(ContentType::json())
+            .json(self)
+    }
+}

--- a/src/model/mod.rs
+++ b/src/model/mod.rs
@@ -1,4 +1,5 @@
 pub mod archive;
+pub mod tarchive;
 mod path_detail;
 pub mod access_list;
 pub mod bookmark_list;

--- a/src/model/tarchive.rs
+++ b/src/model/tarchive.rs
@@ -1,0 +1,77 @@
+use std::io::{Read, Seek};
+use tar::Archive;
+
+pub struct Tarchive;
+
+impl Tarchive {
+    /// Generates a tar index string for the given tar file.
+    /// The index format follows: "filename offset size"
+    pub fn index<R: Read + Seek>(reader: &mut R) -> Result<String, std::io::Error> {
+        let mut archive = Archive::new(reader);
+        let mut index = String::new();
+
+        let entries = archive.entries()?;
+        for entry_result in entries {
+            let entry = entry_result?;
+            let header = entry.header();
+            
+            // We only index files
+            if header.entry_type().is_file() {
+                let path = entry.path()?;
+                let path_str = path.to_str().unwrap_or("");
+                let offset = entry.raw_file_position();
+                let size = entry.header().size()?;
+                
+                index.push_str(&format!("{} {} {}\n", path_str, offset, size));
+            }
+        }
+        
+        Ok(index)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::io::Cursor;
+    use tar::Builder;
+
+    #[test]
+    fn test_tarchive_index() {
+        let mut buf = Vec::new();
+        {
+            let mut builder = Builder::new(&mut buf);
+            
+            let data1 = b"hello world";
+            let mut header1 = tar::Header::new_gnu();
+            header1.set_size(data1.len() as u64);
+            header1.set_path("file1.txt").unwrap();
+            header1.set_cksum();
+            builder.append(&header1, &data1[..]).unwrap();
+
+            let data2 = b"anttp tarchive support";
+            let mut header2 = tar::Header::new_gnu();
+            header2.set_size(data2.len() as u64);
+            header2.set_path("dir/file2.txt").unwrap();
+            header2.set_cksum();
+            builder.append(&header2, &data2[..]).unwrap();
+            
+            builder.finish().unwrap();
+        }
+
+        let mut cursor = Cursor::new(buf);
+        let index = Tarchive::index(&mut cursor).unwrap();
+        
+        let lines: Vec<&str> = index.lines().collect();
+        assert_eq!(lines.len(), 2);
+        assert!(lines[0].starts_with("file1.txt "));
+        assert!(lines[1].starts_with("dir/file2.txt "));
+        
+        // Verify offset and size
+        let parts1: Vec<&str> = lines[0].split_whitespace().collect();
+        assert_eq!(parts1[2], "11");
+        
+        let parts2: Vec<&str> = lines[1].split_whitespace().collect();
+        assert_eq!(parts2[2], "22");
+    }
+}

--- a/src/service/mod.rs
+++ b/src/service/mod.rs
@@ -1,4 +1,5 @@
 pub mod public_archive_service;
+pub mod tarchive_service;
 pub mod file_service;
 pub mod register_service;
 pub mod pointer_service;

--- a/src/service/tarchive_service.rs
+++ b/src/service/tarchive_service.rs
@@ -1,0 +1,132 @@
+use std::{env, fs, io};
+use std::fs::{create_dir, OpenOptions};
+use std::io::Write;
+use std::path::PathBuf;
+use actix_multipart::form::MultipartForm;
+use actix_web::web::Bytes;
+use autonomi::Wallet;
+use log::{info, warn};
+use sanitize_filename::sanitize;
+use uuid::Uuid;
+use tar::Builder;
+
+use crate::service::public_archive_service::{PublicArchiveForm, Upload};
+use crate::service::public_data_service::PublicDataService;
+use crate::error::tarchive_error::TarchiveError;
+use crate::error::UpdateError;
+use crate::controller::StoreType;
+use crate::model::tarchive::Tarchive;
+
+#[derive(Debug)]
+pub struct TarchiveService {
+    public_data_service: PublicDataService,
+}
+
+impl TarchiveService {
+    pub fn new(public_data_service: PublicDataService) -> Self {
+        TarchiveService { public_data_service }
+    }
+
+    pub async fn create_tarchive(&self, public_archive_form: MultipartForm<PublicArchiveForm>, evm_wallet: Wallet, store_type: StoreType) -> Result<Upload, TarchiveError> {
+        info!("Creating new tarchive");
+        let tmp_dir = Self::create_tmp_dir()?;
+        let tar_path = tmp_dir.join("archive.tar");
+
+        // Create new tar file
+        {
+            let tar_file = fs::File::create(&tar_path)?;
+            let mut builder = Builder::new(tar_file);
+
+            for temp_file in public_archive_form.files.iter() {
+                if let Some(raw_file_name) = &temp_file.file_name {
+                    let file_name = sanitize(raw_file_name);
+                    builder.append_path_with_name(temp_file.file.path(), file_name)?;
+                } else {
+                    return Err(UpdateError::TemporaryStorage("Failed to get filename from multipart field".to_string()).into());
+                }
+            }
+            builder.finish()?;
+        }
+
+        // Generate and append index
+        self.append_index(&tar_path)?;
+
+        // Upload as public data
+        let result = self.upload_tar(&tar_path, evm_wallet, store_type).await;
+        Self::purge_tmp_dir(&tmp_dir);
+        result
+    }
+
+    pub async fn update_tarchive(&self, address: String, public_archive_form: MultipartForm<PublicArchiveForm>, evm_wallet: Wallet, store_type: StoreType) -> Result<Upload, TarchiveError> {
+        info!("Updating tarchive at address [{}]", address);
+        let tmp_dir = Self::create_tmp_dir()?;
+        let tar_path = tmp_dir.join("archive.tar");
+
+        // Download existing tar
+        let existing_data = self.public_data_service.get_public_data_binary(address).await?;
+        {
+            let mut tar_file = fs::File::create(&tar_path)?;
+            tar_file.write_all(&existing_data)?;
+        }
+
+        // Append new files
+        {
+            let tar_file = OpenOptions::new().append(true).read(true).open(&tar_path)?;
+            let mut builder = Builder::new(tar_file);
+
+            for temp_file in public_archive_form.files.iter() {
+                if let Some(raw_file_name) = &temp_file.file_name {
+                    let file_name = sanitize(raw_file_name);
+                    builder.append_path_with_name(temp_file.file.path(), file_name)?;
+                } else {
+                    return Err(UpdateError::TemporaryStorage("Failed to get filename from multipart field".to_string()).into());
+                }
+            }
+            builder.finish()?;
+        }
+
+        // Generate and append index
+        self.append_index(&tar_path)?;
+
+        // Upload as public data
+        let result = self.upload_tar(&tar_path, evm_wallet, store_type).await;
+        Self::purge_tmp_dir(&tmp_dir);
+        result
+    }
+
+    fn append_index(&self, tar_path: &PathBuf) -> Result<(), TarchiveError> {
+        let index_str = {
+            let mut tar_file = fs::File::open(tar_path)?;
+            Tarchive::index(&mut tar_file)?
+        };
+
+        let tar_file = OpenOptions::new().append(true).open(tar_path)?;
+        let mut builder = Builder::new(tar_file);
+        
+        let mut header = tar::Header::new_gnu();
+        header.set_size(index_str.len() as u64);
+        header.set_path("archive.tar.idx").unwrap();
+        header.set_cksum();
+        builder.append(&header, index_str.as_bytes())?;
+        builder.finish()?;
+        Ok(())
+    }
+
+    async fn upload_tar(&self, tar_path: &PathBuf, evm_wallet: Wallet, store_type: StoreType) -> Result<Upload, TarchiveError> {
+        let tar_data = fs::read(tar_path)?;
+        let chunk = self.public_data_service.create_public_data(Bytes::from(tar_data), evm_wallet, store_type).await?;
+        Ok(Upload::new(chunk.address))
+    }
+
+    fn create_tmp_dir() -> Result<PathBuf, io::Error> {
+        let random_name = Uuid::new_v4();
+        let tmp_dir = env::temp_dir().as_path().join(random_name.to_string());
+        create_dir(&tmp_dir)?;
+        info!("Created temporary directory for tarchive: {:?}", &tmp_dir);
+        Ok(tmp_dir)
+    }
+
+    fn purge_tmp_dir(tmp_dir: &PathBuf) {
+        fs::remove_dir_all(tmp_dir.clone()).unwrap_or_else(|e| warn!("failed to delete temporary directory at [{:?}]: {}", tmp_dir, e));
+    }
+}


### PR DESCRIPTION
Resolves #35.

This PR adds support for creating and updating Tarchives via the REST interface.

Changes:
- Added `Tarchive` model in `src/model/tarchive.rs` for indexing logic (ported from `tarindexer.py`).
- Added `TarchiveService` in `src/service/tarchive_service.rs` to handle multipart uploads, tar file generation, and appending indices.
- Added REST endpoints in `src/controller/tarchive_controller.rs` (`POST /anttp-0/multipart/tarchive` and `PUT /anttp-0/multipart/tarchive/{address}`).
- Integrated new components into `src/lib.rs` and updated OpenAPI documentation.
- Added unit tests for the indexing logic.
- Incremented version to `0.23.7`.