### PR TITLE
Create gRPC service handler for Tarchive operations #38

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1186,7 +1186,7 @@ dependencies = [
 
 [[package]]
 name = "anttp"
-version = "0.23.7"
+version = "0.23.8"
 dependencies = [
  "actix-files",
  "actix-http",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "anttp"
-version = "0.23.7"
+version = "0.23.8"
 edition = "2024"
 authors = ["Paul Green"]
 description = "AntTP is an HTTP server for the Autonomi Network"

--- a/build.rs
+++ b/build.rs
@@ -7,6 +7,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     tonic_build::compile_protos("proto/pnr.proto")?;
     tonic_build::compile_protos("proto/public_data.proto")?;
     tonic_build::compile_protos("proto/public_archive.proto")?;
+    tonic_build::compile_protos("proto/tarchive.proto")?;
     tonic_build::compile_protos("proto/private_scratchpad.proto")?;
     tonic_build::compile_protos("proto/public_scratchpad.proto")?;
     tonic_build::compile_protos("proto/scratchpad.proto")?;

--- a/proto/tarchive.proto
+++ b/proto/tarchive.proto
@@ -1,0 +1,28 @@
+syntax = "proto3";
+
+package tarchive;
+
+service TarchiveService {
+  rpc CreateTarchive(CreateTarchiveRequest) returns (TarchiveResponse);
+  rpc UpdateTarchive(UpdateTarchiveRequest) returns (TarchiveResponse);
+}
+
+message File {
+  string name = 1;
+  bytes content = 2;
+}
+
+message CreateTarchiveRequest {
+  repeated File files = 1;
+  optional string cache_only = 2;
+}
+
+message UpdateTarchiveRequest {
+  string address = 1;
+  repeated File files = 2;
+  optional string cache_only = 3;
+}
+
+message TarchiveResponse {
+  optional string address = 1;
+}

--- a/src/grpc/mod.rs
+++ b/src/grpc/mod.rs
@@ -6,5 +6,6 @@ pub mod command_handler;
 pub mod pnr_handler;
 pub mod public_data_handler;
 pub mod public_archive_handler;
+pub mod tarchive_handler;
 pub mod private_scratchpad_handler;
 pub mod public_scratchpad_handler;

--- a/src/grpc/tarchive_handler.rs
+++ b/src/grpc/tarchive_handler.rs
@@ -1,0 +1,113 @@
+use tonic::{Request, Response, Status};
+use actix_web::web::Data;
+use ant_evm::EvmWallet;
+use actix_multipart::form::tempfile::TempFile;
+use actix_multipart::form::MultipartForm;
+use std::io::Write;
+use crate::service::public_archive_service::{PublicArchiveForm, Upload};
+use crate::service::tarchive_service::TarchiveService;
+use crate::controller::StoreType;
+use crate::error::tarchive_error::TarchiveError;
+
+pub mod tarchive_proto {
+    tonic::include_proto!("tarchive");
+}
+
+use tarchive_proto::tarchive_service_server::TarchiveService as TarchiveServiceTrait;
+pub use tarchive_proto::tarchive_service_server::TarchiveServiceServer;
+use tarchive_proto::{CreateTarchiveRequest, UpdateTarchiveRequest, TarchiveResponse, File as ProtoFile};
+
+pub struct TarchiveHandler {
+    tarchive_service: Data<TarchiveService>,
+    evm_wallet: Data<EvmWallet>,
+}
+
+impl TarchiveHandler {
+    pub fn new(tarchive_service: Data<TarchiveService>, evm_wallet: Data<EvmWallet>) -> Self {
+        Self { tarchive_service, evm_wallet }
+    }
+
+    fn map_to_multipart_form(&self, files: Vec<ProtoFile>) -> Result<MultipartForm<PublicArchiveForm>, Status> {
+        let mut temp_files = Vec::new();
+        for file in files {
+            let mut temp_file = tempfile::NamedTempFile::new().map_err(|e|
+                Status::internal(format!("Failed to create temp file: {}", e))
+            )?;
+            temp_file.write_all(&file.content).map_err(|e|
+                Status::internal(format!("Failed to write to temp file: {}", e))
+            )?;
+
+            temp_files.push(TempFile {
+                file: temp_file,
+                file_name: Some(file.name),
+                content_type: None,
+                size: file.content.len(),
+            });
+        }
+        Ok(MultipartForm(PublicArchiveForm { files: temp_files }))
+    }
+}
+
+impl From<Upload> for TarchiveResponse {
+    fn from(upload: Upload) -> Self {
+        TarchiveResponse {
+            address: upload.address,
+        }
+    }
+}
+
+impl From<TarchiveError> for Status {
+    fn from(error: TarchiveError) -> Self {
+        Status::internal(error.to_string())
+    }
+}
+
+#[tonic::async_trait]
+impl TarchiveServiceTrait for TarchiveHandler {
+    async fn create_tarchive(
+        &self,
+        request: Request<CreateTarchiveRequest>,
+    ) -> Result<Response<TarchiveResponse>, Status> {
+        let req = request.into_inner();
+        let public_archive_form = self.map_to_multipart_form(req.files)?;
+        
+        let result = self.tarchive_service.create_tarchive(
+            public_archive_form,
+            self.evm_wallet.get_ref().clone(),
+            StoreType::from(req.cache_only.unwrap_or_default())
+        ).await?;
+
+        Ok(Response::new(TarchiveResponse::from(result)))
+    }
+
+    async fn update_tarchive(
+        &self,
+        request: Request<UpdateTarchiveRequest>,
+    ) -> Result<Response<TarchiveResponse>, Status> {
+        let req = request.into_inner();
+        let public_archive_form = self.map_to_multipart_form(req.files)?;
+        
+        let result = self.tarchive_service.update_tarchive(
+            req.address,
+            public_archive_form,
+            self.evm_wallet.get_ref().clone(),
+            StoreType::from(req.cache_only.unwrap_or_default())
+        ).await?;
+
+        Ok(Response::new(TarchiveResponse::from(result)))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[tokio::test]
+    async fn test_mapping() {
+        let upload = Upload {
+            address: Some("0x1234".to_string()),
+        };
+        let response = TarchiveResponse::from(upload);
+        assert_eq!(response.address, Some("0x1234".to_string()));
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -64,6 +64,7 @@ use crate::grpc::command_handler::{CommandHandler, CommandServiceServer};
 use crate::grpc::pnr_handler::{PnrHandler, PnrServiceServer};
 use crate::grpc::public_data_handler::{PublicDataHandler, PublicServiceServer};
 use crate::grpc::public_archive_handler::{PublicArchiveHandler, PublicArchiveServiceServer};
+use crate::grpc::tarchive_handler::{TarchiveHandler, TarchiveServiceServer};
 use crate::grpc::private_scratchpad_handler::{PrivateScratchpadHandler, PrivateScratchpadServiceServer};
 use crate::grpc::public_scratchpad_handler::{PublicScratchpadHandler, PublicScratchpadServiceServer};
 
@@ -190,6 +191,7 @@ pub async fn run_server(ant_tp_config: AntTpConfig) -> io::Result<()> {
     let pnr_handler = PnrHandler::new(pnr_service_data.clone(), evm_wallet_data.clone());
     let public_data_handler = PublicDataHandler::new(public_data_service_data.clone(), evm_wallet_data.clone());
     let public_archive_handler = PublicArchiveHandler::new(public_archive_service_data.clone(), evm_wallet_data.clone());
+    let tarchive_handler = TarchiveHandler::new(tarchive_service_data.clone(), evm_wallet_data.clone());
     let private_scratchpad_handler = PrivateScratchpadHandler::new(scratchpad_service_data.clone(), evm_wallet_data.clone());
     let public_scratchpad_handler = PublicScratchpadHandler::new(scratchpad_service_data.clone(), evm_wallet_data.clone());
     let tonic_server = async move {
@@ -203,6 +205,7 @@ pub async fn run_server(ant_tp_config: AntTpConfig) -> io::Result<()> {
                 .add_service(PnrServiceServer::new(pnr_handler))
                 .add_service(PublicServiceServer::new(public_data_handler))
                 .add_service(PublicArchiveServiceServer::new(public_archive_handler))
+                .add_service(TarchiveServiceServer::new(tarchive_handler))
                 .add_service(PrivateScratchpadServiceServer::new(private_scratchpad_handler))
                 .add_service(PublicScratchpadServiceServer::new(public_scratchpad_handler))
                 .serve(grpc_listen_address),


### PR DESCRIPTION
This PR adds a gRPC endpoint for Tarchive operations, as requested in issue #38.

Changes:
- Created `proto/tarchive.proto` with `TarchiveService` definition.
- Implemented `src/grpc/tarchive_handler.rs` based on `tarchive_controller.rs` and following the pattern of `public_archive_handler.rs`.
- Integrated `TarchiveHandler` in `src/lib.rs` and registered the new gRPC service.
- Added unit tests for the new handler.
- Incremented patch version in `Cargo.toml`.

Note: `File` message type is defined in both `public_archive.proto` and `tarchive.proto` to ensure smooth code generation with `tonic`.