### PR TITLE
Create Tarchive MCP tool #39

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1186,7 +1186,7 @@ dependencies = [
 
 [[package]]
 name = "anttp"
-version = "0.23.8"
+version = "0.23.9"
 dependencies = [
  "actix-files",
  "actix-http",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "anttp"
-version = "0.23.8"
+version = "0.23.9"
 edition = "2024"
 authors = ["Paul Green"]
 description = "AntTP is an HTTP server for the Autonomi Network"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -173,6 +173,7 @@ pub async fn run_server(ant_tp_config: AntTpConfig) -> io::Result<()> {
         graph_service_data.clone(),
         public_archive_service_data.clone(),
         scratchpad_service_data.clone(),
+        tarchive_service_data.clone(),
         evm_wallet_data.clone()
     );
     let mcp_tool_service = StreamableHttpService::builder()

--- a/src/tool/mod.rs
+++ b/src/tool/mod.rs
@@ -7,6 +7,7 @@ use crate::service::register_service::RegisterService;
 use crate::service::graph_service::GraphService;
 use crate::service::public_archive_service::PublicArchiveService;
 use crate::service::scratchpad_service::ScratchpadService;
+use crate::service::tarchive_service::TarchiveService;
 use actix_web::web::Data;
 use ant_evm::EvmWallet;
 use rmcp::handler::server::tool::ToolRouter;
@@ -24,6 +25,7 @@ pub mod graph_tool;
 pub mod public_archive_tool;
 pub mod public_scratchpad_tool;
 pub mod private_scratchpad_tool;
+pub mod tarchive_tool;
 
 #[derive(Debug, Clone)]
 pub struct McpTool {
@@ -36,6 +38,7 @@ pub struct McpTool {
     graph_service: Data<GraphService>,
     public_archive_service: Data<PublicArchiveService>,
     scratchpad_service: Data<ScratchpadService>,
+    tarchive_service: Data<TarchiveService>,
     evm_wallet: Data<EvmWallet>,
     tool_router: ToolRouter<Self>,
 }
@@ -51,6 +54,7 @@ impl McpTool {
         graph_service: Data<GraphService>,
         public_archive_service: Data<PublicArchiveService>,
         scratchpad_service: Data<ScratchpadService>,
+        tarchive_service: Data<TarchiveService>,
         evm_wallet: Data<EvmWallet>
     ) -> Self {
         Self {
@@ -63,6 +67,7 @@ impl McpTool {
             graph_service,
             public_archive_service,
             scratchpad_service,
+            tarchive_service,
             evm_wallet,
             tool_router: Self::chunk_tool_router()
                 + Self::pnr_tool_router()
@@ -74,6 +79,7 @@ impl McpTool {
                 + Self::public_archive_tool_router()
                 + Self::public_scratchpad_tool_router()
                 + Self::private_scratchpad_tool_router()
+                + Self::tarchive_tool_router()
         }
     }
 }

--- a/src/tool/public_archive_tool.rs
+++ b/src/tool/public_archive_tool.rs
@@ -84,7 +84,7 @@ impl McpTool {
         ).await?.into())
     }
 
-    fn map_to_multipart_form(&self, files: HashMap<String, String>) -> Result<MultipartForm<PublicArchiveForm>, ErrorData> {
+    pub(crate) fn map_to_multipart_form(&self, files: HashMap<String, String>) -> Result<MultipartForm<PublicArchiveForm>, ErrorData> {
         let mut temp_files = Vec::new();
         for (name, content_base64) in files {
             let content = BASE64_STANDARD.decode(content_base64).map_err(|e| 

--- a/src/tool/tarchive_tool.rs
+++ b/src/tool/tarchive_tool.rs
@@ -1,0 +1,67 @@
+#![allow(dead_code)]
+
+use std::collections::HashMap;
+use rmcp::{handler::server::{
+    wrapper::Parameters,
+}, schemars, tool, tool_router, ErrorData};
+use rmcp::model::{CallToolResult, ErrorCode};
+use rmcp::schemars::JsonSchema;
+use serde::Deserialize;
+use crate::controller::StoreType;
+use crate::error::tarchive_error::TarchiveError;
+use crate::tool::McpTool;
+
+#[derive(Debug, Deserialize, JsonSchema)]
+struct CreateTarchiveRequest {
+    #[schemars(description = "Base64 encoded content of the files to archive (map of filename to base64 content)")]
+    files: HashMap<String, String>,
+    #[schemars(description = "Store archive on memory, disk or network")]
+    store_type: String,
+}
+
+#[derive(Debug, Deserialize, JsonSchema)]
+struct UpdateTarchiveRequest {
+    #[schemars(description = "Address of the tarchive")]
+    address: String,
+    #[schemars(description = "Base64 encoded content of the files to add to archive (map of filename to base64 content)")]
+    files: HashMap<String, String>,
+    #[schemars(description = "Store archive on memory, disk or network")]
+    store_type: String,
+}
+
+impl From<TarchiveError> for ErrorData {
+    fn from(error: TarchiveError) -> Self {
+        ErrorData::new(ErrorCode::INTERNAL_ERROR, error.to_string(), None)
+    }
+}
+
+#[tool_router(router = tarchive_tool_router, vis = "pub")]
+impl McpTool {
+
+    #[tool(description = "Create a new tarchive")]
+    async fn create_tarchive(
+        &self,
+        Parameters(CreateTarchiveRequest { files, store_type }): Parameters<CreateTarchiveRequest>,
+    ) -> Result<CallToolResult, ErrorData> {
+        let public_archive_form = self.map_to_multipart_form(files)?;
+        Ok(self.tarchive_service.create_tarchive(
+            public_archive_form,
+            self.evm_wallet.get_ref().clone(),
+            StoreType::from(store_type)
+        ).await?.into())
+    }
+
+    #[tool(description = "Update an existing tarchive")]
+    async fn update_tarchive(
+        &self,
+        Parameters(UpdateTarchiveRequest { address, files, store_type }): Parameters<UpdateTarchiveRequest>,
+    ) -> Result<CallToolResult, ErrorData> {
+        let public_archive_form = self.map_to_multipart_form(files)?;
+        Ok(self.tarchive_service.update_tarchive(
+            address,
+            public_archive_form,
+            self.evm_wallet.get_ref().clone(),
+            StoreType::from(store_type)
+        ).await?.into())
+    }
+}


### PR DESCRIPTION
Resolves #39

This PR adds a new MCP tool for `tarchive` as requested.
- Implemented `src/tool/tarchive_tool.rs`.
- Added `TarchiveService` to `McpTool` and registered the router.
- Updated `src/lib.rs` to pass the service.
- Incremented patch version in `Cargo.toml`.
- Reused `map_to_multipart_form` from `public_archive_tool.rs` by making it `pub(crate)`.