### PR TITLE
Add CLI option for disabling gRPC handlers (#45)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1186,7 +1186,7 @@ dependencies = [
 
 [[package]]
 name = "anttp"
-version = "0.23.10"
+version = "0.23.11"
 dependencies = [
  "actix-files",
  "actix-http",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "anttp"
-version = "0.23.10"
+version = "0.23.11"
 edition = "2024"
 authors = ["Paul Green"]
 description = "AntTP is an HTTP server for the Autonomi Network"

--- a/spec/00045_add_cli_option_for_disabling_grpc_handlers.txt
+++ b/spec/00045_add_cli_option_for_disabling_grpc_handlers.txt
@@ -1,0 +1,23 @@
+As a software engineer
+I want an option to disable gRPC handlers
+So that anttp can be customized for specific use cases
+
+Given anttp_config.rs is responsible for managing configuration options
+When adding grpc_disabled option
+Then add a boolean option similar to uploads_disabled
+And use similar annotations, but with long argument only
+And default to false
+And log the argument value like uploads_disabled
+
+Given /src/lib.rs is responsible for enabling/disabling gRPC handlers
+When adding grpc_disabled option
+Then add use this anttp_config value to control whether gRPC handlers are enabled or disabled
+And combine with a checking if uploads disabled is fals, as there are currently write operations
+
+Provide unit tests where applicable for new code.
+
+Implementation Notes
+
+- Place any unit tests at the bottom of the same file as the associated production code
+- Increment patch version of anttp package in Cargo.toml
+- Create a copy of this issue description and save to /spec using the name of this issue as the filename (with lower underscore case, starting with the 5 char padded issue number, e.g. 00001_issue_title.txt)

--- a/src/config/anttp_config.rs
+++ b/src/config/anttp_config.rs
@@ -39,8 +39,11 @@ pub struct AntTpConfig {
     #[arg(short, long, default_value_t = false)]
     pub uploads_disabled: bool,
 
-    #[arg(long, default_value_t = false)]
+    #[arg(short = 'M', long, default_value_t = false)]
     pub mcp_tools_disabled: bool,
+
+    #[arg(long, default_value_t = false)]
+    pub grpc_disabled: bool,
 
     #[arg(short, long, default_value_t = 5)]
     pub cached_mutable_ttl: u64,
@@ -80,6 +83,7 @@ impl AntTpConfig {
         info!("Download threads: [{}]", ant_tp_config.download_threads);
         info!("Uploads disabled: [{}]", ant_tp_config.uploads_disabled);
         info!("MCP tools disabled: [{}]", ant_tp_config.mcp_tools_disabled);
+        info!("gRPC disabled: [{}]", ant_tp_config.grpc_disabled);
         if ant_tp_config.app_private_key.is_empty() {
             info!("No app/personal private key provided. Try this one: [{:?}]", SecretKey::random().to_hex());
         } else {
@@ -140,5 +144,17 @@ mod tests {
     fn test_anttp_config_mcp_tools_disabled_short_arg() {
         let config = AntTpConfig::try_parse_from(&["anttp", "-M"]).unwrap();
         assert!(config.mcp_tools_disabled);
+    }
+
+    #[test]
+    fn test_anttp_config_grpc_disabled_default() {
+        let config = AntTpConfig::try_parse_from(&["anttp"]).unwrap();
+        assert!(!config.grpc_disabled);
+    }
+
+    #[test]
+    fn test_anttp_config_grpc_disabled_long_arg() {
+        let config = AntTpConfig::try_parse_from(&["anttp", "--grpc-disabled"]).unwrap();
+        assert!(config.grpc_disabled);
     }
 }


### PR DESCRIPTION
Resolves #45

Summary of changes:
- Added `grpc_disabled` boolean option to `AntTpConfig` in `src/config/anttp_config.rs`.
- Updated `AntTpConfig::read_args` to log the `grpc_disabled` status.
- Modified `run_server` in `src/lib.rs` to conditionally start the Tonic gRPC server only if both `grpc_disabled` and `uploads_disabled` are false.
- Fixed a move error in `src/lib.rs` by cloning `ant_tp_config` before moving it into the Actix `HttpServer` closure.
- Restored `short = 'M'` for `mcp_tools_disabled` which was missing and causing a test failure.
- Added unit tests for the new `grpc_disabled` configuration option.
- Created `/spec/00045_add_cli_option_for_disabling_grpc_handlers.txt`.
- Incremented patch version in `Cargo.toml` to `0.23.11`.