### PR TITLE
Replace x-cache-only header with x-store-type

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1186,7 +1186,7 @@ dependencies = [
 
 [[package]]
 name = "anttp"
-version = "0.23.12"
+version = "0.23.13"
 dependencies = [
  "actix-files",
  "actix-http",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "anttp"
-version = "0.23.12"
+version = "0.23.13"
 edition = "2024"
 authors = ["Paul Green"]
 description = "AntTP is an HTTP server for the Autonomi Network"

--- a/README.md
+++ b/README.md
@@ -419,11 +419,11 @@ e.g. http://localhost:18888/swagger-ui/ or http://anttp.antsnest.site/swagger-ui
 There are a number of different endpoints for uploading or downloading immutable and mutable data types. To upload data, uploads need to be enabled
 and a valid wallet address must be provided (see 'Run Instructions').
 
-Developers can use the `x-cache-only` header to only upload data to the AntTP instance, instead of uploading to the Autonomi Network. This
+Developers can use the `x-store-type` header to only upload data to the AntTP instance, instead of uploading to the Autonomi Network. This
 provides a number of use cases, from quickly/cheaply testing out new web apps, to local only storage for applications.
 
 Note that when uploading as 'cache only', the files remain on the AntTP instance and there are no charges to upload to the Autonomi Network. If
-the same data is subsequently uploaded without the `x-cache-only` header, it will charge the wallet and upload the data to the network.
+the same data is subsequently uploaded without the `x-store-type` header, it will charge the wallet and upload the data to the network.
 
 Developers should consider how this could easily provide preview modes for uploaded data (e.g. preview a blog before committing to the network),
 local per-user configuration data (e.g. arbitrary data that only the user needs to access), etc.

--- a/spec/00049_replace_x_cache_only_header.txt
+++ b/spec/00049_replace_x_cache_only_header.txt
@@ -1,0 +1,26 @@
+As a REST API consumer
+I want to provide x-store-type header instead of x-cache-only
+So that it is more logical and is consistent with the service layer and other API endpoints
+
+Given x-cache-only header is currently used
+When x-store-type header is used instead
+Then all controller code in /src/controller that uses x-cache-only must be updated to use x-store-type
+And this includes variable names
+And this includes utoipa annotations
+
+Given the postman collection currently uses x-cache-only
+When the header is renamed to x-store-type
+Then the postman collection must be updated to reflect the change in header name
+And newman must be executed to verify the change
+
+Given documentation currently uses x-cache-only
+When the header is renamed to x-store-type
+Then the documentation (in .md files) must be updated to reflect the change in header name
+
+Provide unit tests where applicable for new code.
+
+Implementation Notes
+
+- Place any unit tests at the bottom of the same file as the associated production code
+- Increment patch version of anttp package in Cargo.toml
+- Create a copy of this issue description and save to /spec using the name of this issue as the filename (with lower underscore case, starting with the 5 char padded issue number, e.g. 00001_issue_title.txt)

--- a/src/controller/chunk_controller.rs
+++ b/src/controller/chunk_controller.rs
@@ -19,7 +19,7 @@ use crate::service::chunk_service::{Chunk, ChunkService};
         (status = CREATED, description = "Chunk found successfully", body = Chunk),
     ),
     params(
-        ("x-cache-only", Header, description = "Only persist to cache and do not publish (memory|disk|none)",
+        ("x-store-type", Header, description = "Only persist to cache and do not publish (memory|disk|none)",
         example = "memory"),
     ),
 )]
@@ -45,7 +45,7 @@ pub async fn post_chunk(
         (status = CREATED, description = "Chunk uploaded successfully", body = Chunk),
     ),
     params(
-        ("x-cache-only", Header, description = "Only persist to cache and do not publish (memory|disk|none)",
+        ("x-store-type", Header, description = "Only persist to cache and do not publish (memory|disk|none)",
         example = "memory"),
     ),
 )]

--- a/src/controller/graph_controller.rs
+++ b/src/controller/graph_controller.rs
@@ -17,7 +17,7 @@ use crate::service::graph_service::{GraphEntry, GraphService};
         (status = BAD_REQUEST, description = "Graph entry body was invalid")
     ),
     params(
-        ("x-cache-only", Header, description = "Only persist to cache and do not publish (memory|disk|none)",
+        ("x-store-type", Header, description = "Only persist to cache and do not publish (memory|disk|none)",
         example = "memory"),
     ),
 )]

--- a/src/controller/mod.rs
+++ b/src/controller/mod.rs
@@ -43,8 +43,8 @@ impl From<String> for StoreType {
 
 fn get_store_type(request: &HttpRequest) -> StoreType {
     StoreType::from(
-        match request.headers().get("x-cache-only") {
-            Some(x_cache_only) => x_cache_only.to_str().unwrap_or("").to_string(),
+        match request.headers().get("x-store-type") {
+            Some(x_store_type) => x_store_type.to_str().unwrap_or("").to_string(),
             None => "".to_string()
         }
     )
@@ -100,5 +100,29 @@ mod tests {
         assert_eq!(StoreType::from("network".to_string()), StoreType::Network);
         assert_eq!(StoreType::from("other".to_string()), StoreType::Network);
         assert_eq!(StoreType::from("".to_string()), StoreType::Network);
+    }
+
+    #[test]
+    fn test_get_store_type() {
+        use actix_web::test::TestRequest;
+
+        let req = TestRequest::default()
+            .insert_header(("x-store-type", "memory"))
+            .to_http_request();
+        assert_eq!(get_store_type(&req), StoreType::Memory);
+
+        let req = TestRequest::default()
+            .insert_header(("x-store-type", "disk"))
+            .to_http_request();
+        assert_eq!(get_store_type(&req), StoreType::Disk);
+
+        let req = TestRequest::default()
+            .insert_header(("x-store-type", "network"))
+            .to_http_request();
+        assert_eq!(get_store_type(&req), StoreType::Network);
+
+        let req = TestRequest::default()
+            .to_http_request();
+        assert_eq!(get_store_type(&req), StoreType::Network);
     }
 }

--- a/src/controller/pnr_controller.rs
+++ b/src/controller/pnr_controller.rs
@@ -18,7 +18,7 @@ use crate::service::pnr_service::PnrService;
         (status = BAD_REQUEST, description = "PNR zone body was invalid")
     ),
     params(
-        ("x-cache-only", Header, description = "Only persist to cache and do not publish (memory|disk|none)",
+        ("x-store-type", Header, description = "Only persist to cache and do not publish (memory|disk|none)",
         example = "memory"),
     ),
 )]

--- a/src/controller/pointer_controller.rs
+++ b/src/controller/pointer_controller.rs
@@ -17,7 +17,7 @@ use crate::service::pointer_service::{Pointer, PointerService};
         (status = BAD_REQUEST, description = "Pointer body was invalid")
     ),
     params(
-        ("x-cache-only", Header, description = "Only persist to cache and do not publish (memory|disk|none)",
+        ("x-store-type", Header, description = "Only persist to cache and do not publish (memory|disk|none)",
         example = "memory"),
         ("x-data-key", Header, description = "Private key used to create mutable data (personal|resolver|'custom')",
         example = "personal"),
@@ -40,7 +40,7 @@ pub async fn post_pointer(
     path = "/anttp-0/pointer/{address}",
     params(
         ("address", description = "Address of pointer"),
-        ("x-cache-only", Header, description = "Only persist to cache and do not publish (memory|disk|none)",
+        ("x-store-type", Header, description = "Only persist to cache and do not publish (memory|disk|none)",
         example = "memory"),
         ("x-data-key", Header, description = "Private key used to create mutable data (personal|resolver|'custom')",
         example = "personal"),

--- a/src/controller/private_scratchpad_controller.rs
+++ b/src/controller/private_scratchpad_controller.rs
@@ -17,7 +17,7 @@ use crate::service::scratchpad_service::{Scratchpad, ScratchpadService};
     ),
     params(
         ("name" = String, Path, description = "Private scratchpad name"),
-        ("x-cache-only", Header, description = "Only persist to cache and do not publish (memory|disk|none)",
+        ("x-store-type", Header, description = "Only persist to cache and do not publish (memory|disk|none)",
         example = "memory"),
     ),
 )]
@@ -54,7 +54,7 @@ pub async fn post_private_scratchpad(
     params(
         ("address" = String, Path, description = "Private scratchpad address"),
         ("name" = String, Path, description = "Private scratchpad name"),
-        ("x-cache-only", Header, description = "Only persist to cache and do not publish (memory|disk|none)",
+        ("x-store-type", Header, description = "Only persist to cache and do not publish (memory|disk|none)",
         example = "memory"),
     ),
 )]

--- a/src/controller/public_archive_controller.rs
+++ b/src/controller/public_archive_controller.rs
@@ -18,7 +18,7 @@ use crate::controller::get_store_type;
         (status = CREATED, description = "Public archive created successfully", body = Upload)
     ),
     params(
-        ("x-cache-only", Header, description = "Only persist to cache and do not publish (memory|disk|none)",
+        ("x-store-type", Header, description = "Only persist to cache and do not publish (memory|disk|none)",
         example = "memory"),
     ),
 )]
@@ -48,7 +48,7 @@ pub async fn post_public_archive(
     ),
     params(
         ("address" = String, Path, description = "Public archive address"),
-        ("x-cache-only", Header, description = "Only persist to cache and do not publish (memory|disk|none)",
+        ("x-store-type", Header, description = "Only persist to cache and do not publish (memory|disk|none)",
         example = "memory"),
     ),
 )]

--- a/src/controller/public_data_controller.rs
+++ b/src/controller/public_data_controller.rs
@@ -20,7 +20,7 @@ use crate::service::public_data_service::{PublicData, PublicDataService};
         (status = CREATED, description = "Public data uploaded successfully", body = PublicData),
     ),
     params(
-        ("x-cache-only", Header, description = "Only persist to cache and do not publish (memory|disk|none)",
+        ("x-store-type", Header, description = "Only persist to cache and do not publish (memory|disk|none)",
         example = "memory"),
     ),
 )]

--- a/src/controller/public_scratchpad_controller.rs
+++ b/src/controller/public_scratchpad_controller.rs
@@ -17,7 +17,7 @@ use crate::service::scratchpad_service::{Scratchpad, ScratchpadService};
     ),
     params(
         ("name" = String, Path, description = "Public scratchpad name"),
-        ("x-cache-only", Header, description = "Only persist to cache and do not publish (memory|disk|none)",
+        ("x-store-type", Header, description = "Only persist to cache and do not publish (memory|disk|none)",
         example = "memory"),
     ),
 )]
@@ -54,7 +54,7 @@ pub async fn post_public_scratchpad(
     params(
         ("address" = String, Path, description = "Public scratchpad address"),
         ("name" = String, Path, description = "Public scratchpad name"),
-        ("x-cache-only", Header, description = "Only persist to cache and do not publish (memory|disk|none)",
+        ("x-store-type", Header, description = "Only persist to cache and do not publish (memory|disk|none)",
         example = "memory"),
     ),
 )]

--- a/src/controller/register_controller.rs
+++ b/src/controller/register_controller.rs
@@ -17,7 +17,7 @@ use crate::service::register_service::{Register, RegisterService};
         (status = BAD_REQUEST, description = "Register body was invalid")
     ),
     params(
-        ("x-cache-only", Header, description = "Only persist to cache and do not publish (memory|disk|none)",
+        ("x-store-type", Header, description = "Only persist to cache and do not publish (memory|disk|none)",
         example = "memory"),
     ),
 )]
@@ -39,7 +39,7 @@ pub async fn post_register(
     path = "/anttp-0/register/{address}",
     params(
         ("address", description = "Address of pointer"),
-        ("x-cache-only", Header, description = "Only persist to cache and do not publish (memory|disk|none)",
+        ("x-store-type", Header, description = "Only persist to cache and do not publish (memory|disk|none)",
         example = "memory")
     ),
     request_body(

--- a/src/controller/tarchive_controller.rs
+++ b/src/controller/tarchive_controller.rs
@@ -19,7 +19,7 @@ use crate::controller::get_store_type;
         (status = CREATED, description = "Tarchive created successfully", body = Upload)
     ),
     params(
-        ("x-cache-only", Header, description = "Only persist to cache and do not publish (memory|disk|none)",
+        ("x-store-type", Header, description = "Only persist to cache and do not publish (memory|disk|none)",
         example = "memory"),
     ),
 )]
@@ -49,7 +49,7 @@ pub async fn post_tarchive(
     ),
     params(
         ("address" = String, Path, description = "Tarchive address"),
-        ("x-cache-only", Header, description = "Only persist to cache and do not publish (memory|disk|none)",
+        ("x-store-type", Header, description = "Only persist to cache and do not publish (memory|disk|none)",
         example = "memory"),
     ),
 )]

--- a/test/postman/README.md
+++ b/test/postman/README.md
@@ -60,4 +60,4 @@ Key variables used:
 
 ## Store Type
 
-By default, the requests are configured with `x-cache-only: memory` header and `store_type: memory` in the body (where applicable) to avoid unnecessary persistence during testing.
+By default, the requests are configured with `x-store-type: memory` header and `store_type: memory` in the body (where applicable) to avoid unnecessary persistence during testing.

--- a/test/postman/anttp_postman_collection.json
+++ b/test/postman/anttp_postman_collection.json
@@ -31,7 +31,7 @@
 								"method": "POST",
 								"header": [
 									{
-										"key": "x-cache-only",
+										"key": "x-store-type",
 										"value": "memory",
 										"type": "text"
 									}
@@ -67,7 +67,7 @@
 										"value": "application/octet-stream"
 									},
 									{
-										"key": "x-cache-only",
+										"key": "x-store-type",
 										"value": "memory",
 										"type": "text"
 									}
@@ -95,7 +95,7 @@
 								"method": "GET",
 								"header": [
 									{
-										"key": "x-cache-only",
+										"key": "x-store-type",
 										"value": "memory",
 										"type": "text"
 									}
@@ -119,7 +119,7 @@
 								"method": "GET",
 								"header": [
 									{
-										"key": "x-cache-only",
+										"key": "x-store-type",
 										"value": "memory",
 										"type": "text"
 									}
@@ -163,7 +163,7 @@
 								"method": "POST",
 								"header": [
 									{
-										"key": "x-cache-only",
+										"key": "x-store-type",
 										"value": "memory",
 										"type": "text"
 									}
@@ -195,7 +195,7 @@
 								"method": "PUT",
 								"header": [
 									{
-										"key": "x-cache-only",
+										"key": "x-store-type",
 										"value": "memory",
 										"type": "text"
 									}
@@ -228,7 +228,7 @@
 								"method": "GET",
 								"header": [
 									{
-										"key": "x-cache-only",
+										"key": "x-store-type",
 										"value": "memory",
 										"type": "text"
 									}
@@ -252,7 +252,7 @@
 								"method": "GET",
 								"header": [
 									{
-										"key": "x-cache-only",
+										"key": "x-store-type",
 										"value": "memory",
 										"type": "text"
 									}
@@ -295,7 +295,7 @@
 								"method": "POST",
 								"header": [
 									{
-										"key": "x-cache-only",
+										"key": "x-store-type",
 										"value": "memory",
 										"type": "text"
 									}
@@ -327,7 +327,7 @@
 								"method": "PUT",
 								"header": [
 									{
-										"key": "x-cache-only",
+										"key": "x-store-type",
 										"value": "memory",
 										"type": "text"
 									}
@@ -360,7 +360,7 @@
 								"method": "GET",
 								"header": [
 									{
-										"key": "x-cache-only",
+										"key": "x-store-type",
 										"value": "memory",
 										"type": "text"
 									}
@@ -403,7 +403,7 @@
 								"method": "POST",
 								"header": [
 									{
-										"key": "x-cache-only",
+										"key": "x-store-type",
 										"value": "memory",
 										"type": "text"
 									}
@@ -436,7 +436,7 @@
 								"method": "PUT",
 								"header": [
 									{
-										"key": "x-cache-only",
+										"key": "x-store-type",
 										"value": "memory",
 										"type": "text"
 									}
@@ -470,7 +470,7 @@
 								"method": "GET",
 								"header": [
 									{
-										"key": "x-cache-only",
+										"key": "x-store-type",
 										"value": "memory",
 										"type": "text"
 									}
@@ -514,7 +514,7 @@
 								"method": "POST",
 								"header": [
 									{
-										"key": "x-cache-only",
+										"key": "x-store-type",
 										"value": "memory",
 										"type": "text"
 									}
@@ -547,7 +547,7 @@
 								"method": "PUT",
 								"header": [
 									{
-										"key": "x-cache-only",
+										"key": "x-store-type",
 										"value": "memory",
 										"type": "text"
 									}
@@ -581,7 +581,7 @@
 								"method": "GET",
 								"header": [
 									{
-										"key": "x-cache-only",
+										"key": "x-store-type",
 										"value": "memory",
 										"type": "text"
 									}
@@ -610,7 +610,7 @@
 								"method": "POST",
 								"header": [
 									{
-										"key": "x-cache-only",
+										"key": "x-store-type",
 										"value": "memory",
 										"type": "text"
 									}
@@ -647,7 +647,7 @@
 								"method": "POST",
 								"header": [
 									{
-										"key": "x-cache-only",
+										"key": "x-store-type",
 										"value": "memory",
 										"type": "text"
 									}
@@ -705,7 +705,7 @@
 										"value": "application/octet-stream"
 									},
 									{
-										"key": "x-cache-only",
+										"key": "x-store-type",
 										"value": "memory",
 										"type": "text"
 									}
@@ -733,7 +733,7 @@
 								"method": "GET",
 								"header": [
 									{
-										"key": "x-cache-only",
+										"key": "x-store-type",
 										"value": "memory",
 										"type": "text"
 									}
@@ -763,7 +763,7 @@
 								"method": "POST",
 								"header": [
 									{
-										"key": "x-cache-only",
+										"key": "x-store-type",
 										"value": "memory",
 										"type": "text"
 									}
@@ -803,7 +803,7 @@
 								"method": "GET",
 								"header": [
 									{
-										"key": "x-cache-only",
+										"key": "x-store-type",
 										"value": "memory",
 										"type": "text"
 									}
@@ -831,7 +831,7 @@
 								"method": "POST",
 								"header": [
 									{
-										"key": "x-cache-only",
+										"key": "x-store-type",
 										"value": "memory",
 										"type": "text"
 									}


### PR DESCRIPTION
Resolves #49

### Summary of changes
- Renamed `x-cache-only` header to `x-store-type` across the codebase.
- Updated all controllers in `src/controller/` to use the new header name in code and `utoipa` annotations.
- Updated `get_store_type` in `src/controller/mod.rs` and added unit tests for it.
- Updated `README.md` and `test/postman/README.md`.
- Updated Postman collection in `test/postman/anttp_postman_collection.json`.
- Incremented patch version in `Cargo.toml` to `0.23.13`.
- Created issue specification file in `spec/00049_replace_x_cache_only_header.txt`.