### PR TITLE
Add PNR zone get support

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1186,7 +1186,7 @@ dependencies = [
 
 [[package]]
 name = "anttp"
-version = "0.23.14"
+version = "0.23.15"
 dependencies = [
  "actix-files",
  "actix-http",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "anttp"
-version = "0.23.14"
+version = "0.23.15"
 edition = "2024"
 authors = ["Paul Green"]
 description = "AntTP is an HTTP server for the Autonomi Network"

--- a/spec/00054_add_pnr_zone_get_support.txt
+++ b/spec/00054_add_pnr_zone_get_support.txt
@@ -1,0 +1,39 @@
+As an API consumer
+I want to be able to get PNRs
+So that I can view the current state of the PNR zones
+
+Given pnr_service.rs is responsible for managing PNRs
+When getting a PNR
+Then use get_pointer in pointer_service.rs as an example
+And use update_pnr in pnr_service.rs as an example
+And accept a name as a parameter to lookup the resolver_address
+And use the resolve_address target to lookup the PNR zone chunk
+And then return the PNR zone chunk as a PnrZone
+And refactor update_pnr to share the same function to resolve the PNR zone from the name
+
+Given pnr_controller.rs handles REST request for PNRs
+When updating pnr_service.rs
+Then also update pnr_controller.rs to reflect the new GET operation
+And use put_pnr in pnr_controller.rs as an example
+And use URL format GET /anttp-0/pnr/{name} where name is the PNR name used to define the resolver address
+
+Given /lib.rs is responsible for integrating REST controllers
+When updating pnr_controller.rs
+Then also update /lib.rs to reflect the new GET operation
+And place the new get_pnr function within the primary section where uploads_disabled can be true or false
+And update openapi paths to include get_pnr
+
+Given the postman collection reflects the REST endpoints
+When updating pnr_controller.rs
+Then also update the postman collection to reflect the new GET operation
+And ensure it is added directly after the create and put operations
+And update the associated /test/postman/README.md
+And use newman to confirm both the collection and the new put_pnr endpoint work as expected
+
+Provide unit tests where applicable for new code.
+
+Implementation Notes
+
+- Place any unit tests at the bottom of the same file as the associated production code
+- Increment patch version of anttp package in Cargo.toml
+- Create a copy of this issue description and save to /spec using the name of this issue as the filename (with lower underscore case, starting with the 5 char padded issue number, e.g. 00001_issue_title.txt)

--- a/src/controller/pnr_controller.rs
+++ b/src/controller/pnr_controller.rs
@@ -35,6 +35,28 @@ pub async fn post_pnr(
 }
 
 #[utoipa::path(
+    get,
+    path = "/anttp-0/pnr/{name}",
+    params(
+        ("name", description = "PNR name"),
+    ),
+    responses(
+        (status = OK, description = "PNR zone retrieved successfully", body = PnrZone),
+        (status = NOT_FOUND, description = "PNR zone not found")
+    ),
+)]
+pub async fn get_pnr(
+    path: web::Path<String>,
+    pnr_service: Data<PnrService>,
+) -> Result<HttpResponse, PointerError> {
+    let name = path.into_inner();
+    debug!("Getting PNR zone [{}]", name);
+    Ok(HttpResponse::Ok().json(
+        pnr_service.get_pnr(name).await?
+    ))
+}
+
+#[utoipa::path(
     put,
     path = "/anttp-0/pnr/{name}",
     params(

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -102,6 +102,7 @@ pub async fn run_server(ant_tp_config: AntTpConfig) -> io::Result<()> {
         public_data_controller::get_public_data,
         public_data_controller::post_public_data,
         command_controller::get_commands,
+        pnr_controller::get_pnr,
         pnr_controller::post_pnr,
         pnr_controller::put_pnr
     ))]
@@ -268,6 +269,10 @@ pub async fn run_server(ant_tp_config: AntTpConfig) -> io::Result<()> {
             .route(
                 format!("{}command", API_BASE).as_str(),
                 web::get().to(command_controller::get_commands)
+            )
+            .route(
+                format!("{}pnr/{{name}}", API_BASE).as_str(),
+                web::get().to(pnr_controller::get_pnr)
             )
             .route(
                 "/{path:.*}",

--- a/test/postman/README.md
+++ b/test/postman/README.md
@@ -16,7 +16,7 @@ The collection `anttp_postman_collection.json` provides a comprehensive set of R
 - **Public Data**: Create and retrieve public data (binary).
 - **Tarchive**: Create and update tarchives (TAR-based archives).
 - **Command**: Retrieve the list of background commands.
-- **PNR**: Create and update PNR (Pointer Name Record) zones.
+- **PNR**: Create, update, and retrieve PNR (Pointer Name Record) zones.
 
 ## Prerequisites
 

--- a/test/postman/anttp_postman_collection.json
+++ b/test/postman/anttp_postman_collection.json
@@ -888,14 +888,32 @@
 										"test_pnr"
 									]
 								}
-							}
-						}
-					]
-				}
-			]
-		}
-	],
-	"variable": [
+                                                        }
+                                                },
+                                                {
+                                                        "name": "Get PNR",
+                                                        "request": {
+                                                                "method": "GET",
+                                                                "header": [],
+                                                                "url": {
+                                                                        "raw": "{{base_url}}/anttp-0/pnr/test_pnr",
+                                                                        "host": [
+                                                                               "{{base_url}}"
+                                                                        ],
+                                                                        "path": [
+                                                                               "anttp-0",
+                                                                               "pnr",
+                                                                               "test_pnr"
+                                                                        ]
+                                                                }
+                                                        }
+                                                }
+                                        ]
+                                }
+                        ]
+                }
+        ],
+        "variable": [
 		{
 			"key": "base_url",
 			"value": "http://localhost:18888",


### PR DESCRIPTION
Resolves #54

### Changes:
- Refactored `update_pnr` in `PnrService` to share PNR zone resolution logic via a new private function `resolve_pnr_addresses`.
- Implemented `get_pnr` in `PnrService` to retrieve and deserialize a PNR zone from its personal pointer address.
- Added `get_pnr` endpoint to `PnrController` accessible via `GET /anttp-0/pnr/{name}`.
- Registered the new endpoint in `lib.rs` and updated OpenAPI documentation.
- Updated Postman collection and README with the new GET operation.
- Incremented patch version in `Cargo.toml` to `0.23.15`.
- Added a spec file for the issue in `spec/00054_add_pnr_zone_get_support.txt`.