### PR TITLE
Add get PNR support to MCP APIs

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "anttp"
-version = "0.23.16"
+version = "0.23.17"
 edition = "2024"
 authors = ["Paul Green"]
 description = "AntTP is an HTTP server for the Autonomi Network"

--- a/spec/00060_add_get_pnr_support_to_mcp_apis.txt
+++ b/spec/00060_add_get_pnr_support_to_mcp_apis.txt
@@ -1,0 +1,21 @@
+As an MCP tool API consumer
+I want to be able to get PNRs
+So that I can view the current state of the PNR zones
+
+Given pnr_tool.rs handles MCP tool request for PNRs
+When adding GET PNR support
+Then update pnr_tool.rs to include a get_pnr_zone function
+And use pointer_tool.rs as a reference
+And apply #[tool] annotation to get_pnr_zone
+
+Given pnr_service.rs implements get_pnr
+When adding GET PNR support
+Then call get_pnr in a similar way to pnr_controller.rs
+
+Provide unit tests where applicable for new code.
+
+Implementation Notes
+
+- Place any unit tests at the bottom of the same file as the associated production code
+- Increment patch version of anttp package in Cargo.toml
+- Create a copy of this issue description and save to /spec using the name of this issue as the filename (with lower underscore case, starting with the 5 char padded issue number, e.g. 00060_issue_title.txt)

--- a/src/tool/pnr_tool.rs
+++ b/src/tool/pnr_tool.rs
@@ -23,6 +23,12 @@ struct PnrRequest {
     store_type: String,
 }
 
+#[derive(Debug, Deserialize, JsonSchema)]
+struct GetPnrRequest {
+    #[schemars(description = "Name of the PNR zone")]
+    name: String,
+}
+
 #[derive(Debug, Serialize, JsonSchema)]
 struct PnrResponse {
     #[schemars(description = "Name of the PNR zone")]
@@ -61,5 +67,42 @@ impl McpTool {
         Ok(self.pnr_service.create_pnr(
             pnr_zone, self.evm_wallet.get_ref().clone(), StoreType::from(store_type)
         ).await?.into())
+    }
+
+    #[tool(description = "Get PNR zone by name")]
+    async fn get_pnr_zone(
+        &self,
+        Parameters(GetPnrRequest { name }): Parameters<GetPnrRequest>,
+    ) -> Result<CallToolResult, ErrorData> {
+        Ok(self.pnr_service.get_pnr(name).await?.into())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[tokio::test]
+    async fn test_get_pnr_request_serialization() {
+        let json = r#"{
+            "name": "test_pnr"
+        }"#;
+        let request: GetPnrRequest = serde_json::from_str(json).unwrap();
+        assert_eq!(request.name, "test_pnr");
+    }
+
+    #[tokio::test]
+    async fn test_pnr_request_serialization() {
+        let json = r#"{
+            "name": "test_pnr",
+            "address": "0x123",
+            "ttl": 60,
+            "store_type": "memory"
+        }"#;
+        let request: PnrRequest = serde_json::from_str(json).unwrap();
+        assert_eq!(request.name, "test_pnr");
+        assert_eq!(request.address, "0x123");
+        assert_eq!(request.ttl, 60);
+        assert_eq!(request.store_type, "memory");
     }
 }


### PR DESCRIPTION
Resolves #60

This PR adds support for retrieving PNR zones via the MCP API.

Changes:
- Added `get_pnr_zone` tool to `src/tool/pnr_tool.rs`.
- Added `GetPnrRequest` struct for the new tool.
- Added unit tests for PNR request serialization.
- Incremented patch version in `Cargo.toml`.
- Added issue description to `spec/00060_add_get_pnr_support_to_mcp_apis.txt`.