### PR TITLE
Add update PNR support to gRPC APIs

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1186,7 +1186,7 @@ dependencies = [
 
 [[package]]
 name = "anttp"
-version = "0.23.16"
+version = "0.23.18"
 dependencies = [
  "actix-files",
  "actix-http",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "anttp"
-version = "0.23.17"
+version = "0.23.18"
 edition = "2024"
 authors = ["Paul Green"]
 description = "AntTP is an HTTP server for the Autonomi Network"

--- a/proto/pnr.proto
+++ b/proto/pnr.proto
@@ -4,6 +4,7 @@ package pnr;
 
 service PnrService {
   rpc CreatePnr(CreatePnrRequest) returns (PnrResponse);
+  rpc UpdatePnr(UpdatePnrRequest) returns (PnrResponse);
   rpc GetPnr(GetPnrRequest) returns (PnrResponse);
 }
 
@@ -29,6 +30,12 @@ enum PnrRecordType {
 message CreatePnrRequest {
   PnrZone pnr_zone = 1;
   optional string cache_only = 2;
+}
+
+message UpdatePnrRequest {
+  string name = 1;
+  PnrZone pnr_zone = 2;
+  optional string cache_only = 3;
 }
 
 message GetPnrRequest {

--- a/spec/00061_add_update_pnr_support_to_grpc_apis.txt
+++ b/spec/00061_add_update_pnr_support_to_grpc_apis.txt
@@ -1,0 +1,28 @@
+As an gRPC API consumer
+I want to be able to update PNRs
+So that I can edit the current state of the PNR zones
+
+Given pnr_handler.rs handles gRPC request for PNRs
+When adding update PNR support
+Then update pnr_handler.rs to include an update_pnr function
+And use pointer_handler.rs as a reference
+
+Given pnr_service.rs implements update_pnr
+When adding update PNR support
+Then call update_pnr in a similar way to pnr_controller.rs
+
+Given gRPC requires protobuffer definitions
+When adding update PNR support
+Then update gRPC service definition for PNR update request/response messages in /proto/pnr.proto
+
+Given gRPC needs to be integrated with Tonic server
+When adding update PNR gRPC endpoint
+Then update build.rs to include pnr.proto changes
+
+Provide unit tests where applicable for new code.
+
+Implementation Notes
+
+- Place any unit tests at the bottom of the same file as the associated production code
+- Increment patch version of anttp package in Cargo.toml
+- Create a copy of this issue description and save to /spec using the name of this issue as the filename (with lower underscore case, starting with the 5 char padded issue number, e.g. 00001_issue_title.txt)


### PR DESCRIPTION
Resolves #61

This PR adds update PNR support to the gRPC APIs.

Changes:
- Added `UpdatePnr` RPC and `UpdatePnrRequest` message to `proto/pnr.proto`.
- Implemented `update_pnr` in `src/grpc/pnr_handler.rs`.
- Added unit tests for mapping logic in `src/grpc/pnr_handler.rs`.
- Incremented patch version in `Cargo.toml` to `0.23.18`.
- Added spec file `spec/00061_add_update_pnr_support_to_grpc_apis.txt`.