### PR TITLE
feat: add update PNR support to MCP tool API (#63)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1186,7 +1186,7 @@ dependencies = [
 
 [[package]]
 name = "anttp"
-version = "0.23.18"
+version = "0.23.19"
 dependencies = [
  "actix-files",
  "actix-http",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "anttp"
-version = "0.23.18"
+version = "0.23.19"
 edition = "2024"
 authors = ["Paul Green"]
 description = "AntTP is an HTTP server for the Autonomi Network"

--- a/spec/00063_add_update_pnr_support_to_mcp_tool_api.txt
+++ b/spec/00063_add_update_pnr_support_to_mcp_tool_api.txt
@@ -1,0 +1,28 @@
+As an MCP tool API consumer
+I want to be able to update PNRs
+So that I can edit the current state of the PNR zones
+
+Given pnr_handler.rs handles MCP tool request for PNRs
+When adding update PNR support
+Then update pnr_handler.rs to include a update_pnr_zone function
+And use pointer_handler.rs as a reference
+
+Given pnr_service.rs implements update_pnr
+When adding update PNR support
+Then call update_pnr in a similar way to pnr_controller.rs
+
+Given gRPC requires protobuffer definitions
+When adding update PNR support
+Then update gRPC service definition for update PNR zone request/response messages in /proto/pnr.proto
+
+Given gRPC needs to be integrated with Tonic server
+When adding update PNR gRPC endpoint
+Then update build.rs to include pnr.proto changes
+
+Provide unit tests where applicable for new code.
+
+Implementation Notes
+
+- Place any unit tests at the bottom of the same file as the associated production code
+- Increment patch version of anttp package in Cargo.toml
+- Create a copy of this issue description and save to /spec using the name of this issue as the filename (with lower underscore case, starting with the 5 char padded issue number, e.g. 00063_issue_title.txt)


### PR DESCRIPTION
Resolves #63

This PR adds support for updating PNR zones via the MCP tool API.

Changes:
- Added `UpdatePnrRequest` struct for MCP tool parameters in `src/tool/pnr_tool.rs`.
- Implemented `update_pnr_zone` tool in `McpTool` within `src/tool/pnr_tool.rs`.
- Added unit tests for the new request serialization.
- Incremented package version to 0.23.19 in `Cargo.toml`.
- Added spec file `spec/00063_add_update_pnr_support_to_mcp_tool_api.txt`.

Verification:
- Ran `cargo test pnr_tool` and all tests passed.