### PR TITLE
Add unit tests for ChunkService #69

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1186,7 +1186,7 @@ dependencies = [
 
 [[package]]
 name = "anttp"
-version = "0.23.20"
+version = "0.23.21"
 dependencies = [
  "actix-files",
  "actix-http",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "anttp"
-version = "0.23.20"
+version = "0.23.21"
 edition = "2024"
 authors = ["Paul Green"]
 description = "AntTP is an HTTP server for the Autonomi Network"

--- a/spec/00069_add_unit_tests_for_chunk_service_by_mocking_chunk_caching_client.txt
+++ b/spec/00069_add_unit_tests_for_chunk_service_by_mocking_chunk_caching_client.txt
@@ -1,0 +1,17 @@
+As a software engineer
+I want to have good code coverage of ChunkService
+So that I can have confidence that changes won't break existing functionality
+
+Given mockall can be used to mock struct impl dependencies
+When adding unit tests to ChunkService
+Then create mockall mocks to create mock instances of ChunkCachingClient
+And use these mocks to test ChunkService methods
+And use 'mock!' to define test doubles whose actions can be mocked
+And use PointerService in pointer_service.rs and PointerCachingClient in pointer_caching_client.rs as examples
+
+Implementation Notes
+
+- Place any unit tests at the bottom of the same file as the associated production code
+- Increment patch version of anttp package in Cargo.toml
+- Create a copy of this issue description and save to /spec using the name of this issue as the filename (with lower underscore case, starting with the 5 char padded issue number, e.g. 00069_add_unit_tests_for_chunk_service_by_mocking_chunk_caching_client.txt)
+- Fix failing unit tests in ChunkService and improve coverage

--- a/src/client/chunk_caching_client.rs
+++ b/src/client/chunk_caching_client.rs
@@ -4,6 +4,7 @@ use autonomi::client::payment::PaymentOption;
 use bytes::Bytes;
 use chunk_streamer::chunk_streamer::ChunkGetter;
 use log::{debug, error, info};
+use mockall::mock;
 use crate::client::CachingClient;
 use crate::client::command::chunk::create_chunk_command::CreateChunkCommand;
 use crate::error::chunk_error::ChunkError;
@@ -12,6 +13,23 @@ use crate::controller::StoreType;
 #[derive(Debug, Clone)]
 pub struct ChunkCachingClient {
     caching_client: CachingClient,
+}
+
+mock! {
+    #[derive(Debug)]
+    pub ChunkCachingClient {
+        pub fn new(caching_client: CachingClient) -> Self;
+        pub async fn chunk_put(
+            &self,
+            chunk: &Chunk,
+            payment_option: PaymentOption,
+            store_type: StoreType
+        ) -> Result<ChunkAddress, ChunkError>;
+        pub async fn chunk_get_internal(&self, address: &ChunkAddress) -> Result<Chunk, ChunkError>;
+    }
+    impl Clone for ChunkCachingClient {
+        fn clone(&self) -> Self;
+    }
 }
 
 impl ChunkCachingClient {

--- a/src/client/mod.rs
+++ b/src/client/mod.rs
@@ -38,7 +38,7 @@ pub mod public_data_caching_client;
 pub mod command;
 
 pub use self::caching_client::*;
-pub use chunk_caching_client::ChunkCachingClient;
+pub use chunk_caching_client::{ChunkCachingClient, MockChunkCachingClient};
 pub use scratchpad_caching_client::ScratchpadCachingClient;
 pub use graph_entry_caching_client::GraphEntryCachingClient;
 pub use pointer_caching_client::PointerCachingClient;

--- a/src/service/chunk_service.rs
+++ b/src/service/chunk_service.rs
@@ -1,18 +1,20 @@
-use autonomi::{ChunkAddress, Wallet};
+use autonomi::{ChunkAddress, Wallet, Network};
 use autonomi::client::chunk as autonomi_chunk;
 use autonomi::client::payment::PaymentOption;
 use base64::Engine;
 use base64::prelude::BASE64_STANDARD;
 use bytes::Bytes;
 use log::{info, warn};
+use mockall_double::double;
 use serde::{Deserialize, Serialize};
 use utoipa::ToSchema;
+#[double]
 use crate::client::ChunkCachingClient;
 use crate::error::{CreateError, GetError};
 use crate::error::chunk_error::ChunkError;
 use crate::controller::StoreType;
 
-#[derive(Serialize, Deserialize, ToSchema, Clone)]
+#[derive(Serialize, Deserialize, ToSchema, Clone, Debug)]
 pub struct Chunk {
     pub content: Option<String>,
     #[schema(read_only)]
@@ -88,6 +90,156 @@ impl ChunkService {
                 }
             },
             Err(e) => Err(ChunkError::GetError(GetError::BadAddress(e.to_string()))),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use mockall::predicate::*;
+    use crate::client::MockChunkCachingClient;
+
+    fn create_test_service(mock_client: MockChunkCachingClient) -> ChunkService {
+        ChunkService::new(mock_client)
+    }
+
+    #[tokio::test]
+    async fn test_create_chunk_binary_success() {
+        let mut mock_client = MockChunkCachingClient::default();
+        let bytes = Bytes::from("test content");
+        let wallet = Wallet::new_with_random_wallet(Network::ArbitrumOne);
+        let store_type = StoreType::Network;
+
+        mock_client
+            .expect_chunk_put()
+            .with(always(), always(), eq(store_type.clone()))
+            .times(1)
+            .returning(|_, _, _| Ok(ChunkAddress::from_hex("0000000000000000000000000000000000000000000000000000000000000000").unwrap()));
+
+        let service = create_test_service(mock_client);
+        let result = service.create_chunk_binary(bytes, wallet, store_type).await;
+
+        assert!(result.is_ok());
+        let chunk = result.unwrap();
+        assert_eq!(chunk.address, Some("0000000000000000000000000000000000000000000000000000000000000000".to_string()));
+    }
+
+    #[tokio::test]
+    async fn test_create_chunk_success() {
+        let mut mock_client = MockChunkCachingClient::default();
+        let content = BASE64_STANDARD.encode("test content");
+        let chunk_input = Chunk::new(Some(content), None);
+        let wallet = Wallet::new_with_random_wallet(Network::ArbitrumOne);
+        let store_type = StoreType::Network;
+
+        mock_client
+            .expect_chunk_put()
+            .with(always(), always(), eq(store_type.clone()))
+            .times(1)
+            .returning(|_, _, _| Ok(ChunkAddress::from_hex("0000000000000000000000000000000000000000000000000000000000000000").unwrap()));
+
+        let service = create_test_service(mock_client);
+        let result = service.create_chunk(chunk_input, wallet, store_type).await;
+
+        assert!(result.is_ok());
+        let chunk = result.unwrap();
+        assert_eq!(chunk.address, Some("0000000000000000000000000000000000000000000000000000000000000000".to_string()));
+    }
+
+    #[tokio::test]
+    async fn test_create_chunk_empty_payload_error() {
+        let mock_client = MockChunkCachingClient::default();
+        let chunk_input = Chunk::new(None, None);
+        let wallet = Wallet::new_with_random_wallet(Network::ArbitrumOne);
+        let store_type = StoreType::Network;
+
+        let service = create_test_service(mock_client);
+        let result = service.create_chunk(chunk_input, wallet, store_type).await;
+
+        assert!(result.is_err());
+        match result.unwrap_err() {
+            ChunkError::CreateError(CreateError::InvalidData(msg)) => assert_eq!(msg, "Empty chunk payload"),
+            _ => panic!("Expected InvalidData error"),
+        }
+    }
+
+    #[tokio::test]
+    async fn test_get_chunk_binary_success() {
+        let mut mock_client = MockChunkCachingClient::default();
+        let address_hex = "0000000000000000000000000000000000000000000000000000000000000000";
+        let chunk_address = ChunkAddress::from_hex(address_hex).unwrap();
+        let expected_bytes = Bytes::from("test content");
+
+        mock_client
+            .expect_chunk_get_internal()
+            .with(eq(chunk_address))
+            .times(1)
+            .returning(move |_| Ok(autonomi::Chunk::new(expected_bytes.clone())));
+
+        let service = create_test_service(mock_client);
+        let result = service.get_chunk_binary(address_hex.to_string()).await;
+
+        assert!(result.is_ok());
+        assert_eq!(result.unwrap().value, Bytes::from("test content"));
+    }
+
+    #[tokio::test]
+    async fn test_get_chunk_binary_not_found_error() {
+        let mut mock_client = MockChunkCachingClient::default();
+        let address_hex = "0000000000000000000000000000000000000000000000000000000000000000";
+        let chunk_address = ChunkAddress::from_hex(address_hex).unwrap();
+
+        mock_client
+            .expect_chunk_get_internal()
+            .with(eq(chunk_address))
+            .times(1)
+            .returning(|_| Err(ChunkError::GetError(GetError::RecordNotFound("Not found".to_string()))));
+
+        let service = create_test_service(mock_client);
+        let result = service.get_chunk_binary(address_hex.to_string()).await;
+
+        assert!(result.is_err());
+        match result.unwrap_err() {
+            ChunkError::GetError(GetError::RecordNotFound(_)) => (),
+            _ => panic!("Expected RecordNotFound error"),
+        }
+    }
+
+    #[tokio::test]
+    async fn test_get_chunk_success() {
+        let mut mock_client = MockChunkCachingClient::default();
+        let address_hex = "0000000000000000000000000000000000000000000000000000000000000000";
+        let chunk_address = ChunkAddress::from_hex(address_hex).unwrap();
+        let expected_bytes = Bytes::from("test content");
+
+        mock_client
+            .expect_chunk_get_internal()
+            .with(eq(chunk_address))
+            .times(1)
+            .returning(move |_| Ok(autonomi::Chunk::new(expected_bytes.clone())));
+
+        let service = create_test_service(mock_client);
+        let result = service.get_chunk(address_hex.to_string()).await;
+
+        assert!(result.is_ok());
+        let chunk = result.unwrap();
+        assert_eq!(chunk.content, Some(BASE64_STANDARD.encode("test content")));
+        assert_eq!(chunk.address, Some(address_hex.to_string()));
+    }
+
+    #[tokio::test]
+    async fn test_get_chunk_bad_address_error() {
+        let mock_client = MockChunkCachingClient::default();
+        let address_hex = "invalid_address";
+
+        let service = create_test_service(mock_client);
+        let result = service.get_chunk(address_hex.to_string()).await;
+
+        assert!(result.is_err());
+        match result.unwrap_err() {
+            ChunkError::GetError(GetError::BadAddress(_)) => (),
+            _ => panic!("Expected BadAddress error"),
         }
     }
 }


### PR DESCRIPTION
Resolves issue #69.
This PR adds unit tests for `ChunkService` by mocking `ChunkCachingClient` using `mockall`.
- Implemented `mock!` for `ChunkCachingClient`.
- Updated `ChunkService` to use `#[double]` for `ChunkCachingClient`.
- Added unit tests for all `ChunkService` methods in `src/service/chunk_service.rs`.
- Incremented patch version in `Cargo.toml`.
- Added spec file.