### PR TITLE
Add Newman tests to GitHub workflow #48

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -28,6 +28,15 @@ jobs:
       run: cargo build --release --target x86_64-unknown-linux-musl
     - name: Run tests
       run: cargo test --verbose
+    - name: Install npm
+      run: sudo apt-get install -y npm
+    - name: Install newman
+      run: sudo npm install -g newman
+    - name: Run Newman tests
+      run: |
+        ./target/x86_64-unknown-linux-musl/release/anttp &
+        sleep 5
+        newman run ./test/postman/anttp_postman_collection.json
     - name: Install mingw-w64
       run: sudo apt-get install mingw-w64
     - name: Install x86_64-pc-windows-gnu target

--- a/spec/00048_add_newman_to_the_github_build_workflow.txt
+++ b/spec/00048_add_newman_to_the_github_build_workflow.txt
@@ -1,0 +1,25 @@
+As a software engineer
+I want to validate that new builds function as expected
+So that quality assurance can be improved
+
+Given there is an existing workflow in .github/workflows/rust.yml
+When a new commit is pushed to github
+Then after the application is built, newman should be run against the application
+And confirm that newman exists with a status code of 0
+
+Given newman and npm will not be installed by the build workflow
+When adding newman
+Then add a step to install npm
+And a step to install newman using npm
+
+Given the build workflow includes several architectures
+When adding newman
+Then only run newman on linux x64 to reduce execution time
+
+Given newman needs to run a collection
+When newman is executed
+Then use the collection located at /test/postman/anttp.postman_collection.json
+
+Implementation Notes
+
+- Create a copy of this issue description and save to /spec using the name of this issue as the filename (with lower underscore case, starting with the 5 char padded issue number, e.g. 00001_issue_title.txt)


### PR DESCRIPTION
Resolves #48

This PR adds Newman integration tests to the GitHub Actions workflow.

Changes:
- Added a spec file for the issue in `spec/`.
- Updated `.github/workflows/rust.yml` to:
  - Install `npm` and `newman`.
  - Start the `anttp` server in the background after it's built for `x86_64-unknown-linux-musl`.
  - Run the Newman collection against the local server.
  - The tests run only on the `ubuntu-latest` (linux x64) runner.