### PR TITLE
Store PnrZone records as a key/value map (Issue #86)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1186,7 +1186,7 @@ dependencies = [
 
 [[package]]
 name = "anttp"
-version = "0.23.25"
+version = "0.23.26"
 dependencies = [
  "actix-files",
  "actix-http",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "anttp"
-version = "0.23.25"
+version = "0.23.26"
 edition = "2024"
 authors = ["Paul Green"]
 description = "AntTP is an HTTP server for the Autonomi Network"

--- a/proto/pnr.proto
+++ b/proto/pnr.proto
@@ -10,13 +10,12 @@ service PnrService {
 
 message PnrZone {
   string name = 1;
-  repeated PnrRecord records = 2;
+  map<string, PnrRecord> records = 2;
   optional string resolver_address = 3;
   optional string personal_address = 4;
 }
 
 message PnrRecord {
-  optional string sub_name = 1;
   string address = 2;
   PnrRecordType record_type = 3;
   uint64 ttl = 4;

--- a/spec/00086_store_pnr_zone_records_as_a_key_value_map_to_easily_resolve_a_sub_name_to_an_address.txt
+++ b/spec/00086_store_pnr_zone_records_as_a_key_value_map_to_easily_resolve_a_sub_name_to_an_address.txt
@@ -1,0 +1,42 @@
+As a software engineer
+I want to store PnrZone records as a key/value map to easily resolve a sub name to an address
+So that I can have confidence that changes won't break existing functionality
+
+Given that resolving a sub-name to an address will be a common operation
+When storing and retrieving PnrZone records
+Then the key to the PnrRecord should be the sub-name
+And the sub-name should be removed from the PnrRecord
+
+Given the postman collection has tests for PNR create/update
+When the records value is changed to a map
+Then the postman collection should be updated
+And newman should be used to validate
+
+Implementation Notes
+
+- Place any unit tests at the bottom of the same file as the associated production code
+- Increment patch version of anttp package in Cargo.toml
+- Create a copy of this issue description and save to /spec using the name of this issue as the filename (with lower underscore case, starting with the 5 char padded issue number, e.g. 00001_issue_title.txt)
+- PnrZone.records should use type HashMap
+
+Example new JSON:
+
+```
+{
+  "name": "testname",
+  "records": {
+    "": {
+      "address": "a33082163be512fb471a1cca385332b32c19917deec3989a97e100d827f97baf",
+      "record_type": "X",
+      "ttl": 60
+    },
+    "subname2": {
+      "address": "b33082163be512fb471a1cca385332b32c19917deec3989a97e100d827f97baf",
+      "record_type": "A",
+      "ttl": 30
+    }
+  },
+  "resolver_address":null,
+  "personal_address":null
+}
+```

--- a/src/model/pnr.rs
+++ b/src/model/pnr.rs
@@ -1,10 +1,11 @@
+use std::collections::HashMap;
 use serde::{Deserialize, Serialize};
 use utoipa::ToSchema;
 
 #[derive(Clone, Debug, Serialize, Deserialize, ToSchema)]
 pub struct PnrZone {
     pub name: String,
-    pub records: Vec<PnrRecord>,
+    pub records: HashMap<String, PnrRecord>,
     #[schema(read_only)]
     pub resolver_address: Option<String>,
     #[schema(read_only)]
@@ -12,22 +13,21 @@ pub struct PnrZone {
 }
 
 impl PnrZone {
-    pub fn new(name: String, records: Vec<PnrRecord>, resolver_address: Option<String>, personal_address: Option<String>) -> Self {
+    pub fn new(name: String, records: HashMap<String, PnrRecord>, resolver_address: Option<String>, personal_address: Option<String>) -> Self {
         Self { name, records, resolver_address, personal_address }
     }
 }
 
 #[derive(Clone, Debug, Serialize, Deserialize, ToSchema)]
 pub struct PnrRecord {
-    pub sub_name: Option<String>,
     pub address: String,
     pub record_type: PnrRecordType,
     pub ttl: u64,
 }
 
 impl PnrRecord {
-    pub fn new(sub_name: Option<String>, address: String, record_type: PnrRecordType, ttl: u64) -> Self {
-        Self { sub_name, address, record_type, ttl }
+    pub fn new(address: String, record_type: PnrRecordType, ttl: u64) -> Self {
+        Self { address, record_type, ttl }
     }
 }
 

--- a/src/service/pointer_name_resolver.rs
+++ b/src/service/pointer_name_resolver.rs
@@ -109,11 +109,9 @@ impl PointerNameResolver {
                     match serde_json::from_slice::<PnrZone>(&chunk.value) {
                         Ok(pnr_zone) => {
                             debug!("deserialized {} PNR records", pnr_zone.records.len());
-                            for pnr_record in pnr_zone.records {
-                                if pnr_record.sub_name.unwrap_or("".to_string()).is_empty() {
-                                    debug!("found default PNR record");
-                                    return Some(ResolvedRecord::new(pnr_record.address.to_string(), pnr_record.ttl));
-                                }
+                            if let Some(pnr_record) = pnr_zone.records.get("") {
+                                debug!("found default PNR record");
+                                return Some(ResolvedRecord::new(pnr_record.address.to_string(), pnr_record.ttl));
                             }
                             debug!("no default PNR record found");
                             None
@@ -140,6 +138,7 @@ impl PointerNameResolver {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::collections::HashMap;
     use crate::client::MockChunkCachingClient;
     use crate::client::MockPointerCachingClient;
     use crate::model::pnr::{PnrRecord, PnrRecordType};
@@ -225,7 +224,7 @@ mod tests {
         let resolved_address = "b40e045a6fbed33b27039aa8383c9dbf286e19a7265141c2da3085e0c8571527".to_string();
         let pnr_zone = PnrZone::new(
             "test.name".to_string(),
-            vec![PnrRecord::new(None, resolved_address.clone(), PnrRecordType::A, 60)],
+            HashMap::from([("".to_string(), PnrRecord::new(resolved_address.clone(), PnrRecordType::A, 60))]),
             None,
             None
         );

--- a/src/tool/pnr_tool.rs
+++ b/src/tool/pnr_tool.rs
@@ -1,5 +1,6 @@
 #![allow(dead_code)]
 
+use std::collections::HashMap;
 use rmcp::{handler::server::{
     wrapper::Parameters,
 }, schemars, tool, tool_router, ErrorData};
@@ -72,7 +73,7 @@ impl McpTool {
         let ttl_or_default = if ttl == 0 { 60 } else { ttl };
         let pnr_zone = PnrZone::new(
             name,
-            vec![PnrRecord::new(Some("".to_string()), address.clone(), PnrRecordType::X, ttl_or_default)],
+            HashMap::from([("".to_string(), PnrRecord::new(address.clone(), PnrRecordType::X, ttl_or_default))]),
             None,
             None
         );
@@ -89,7 +90,7 @@ impl McpTool {
         let ttl_or_default = if ttl == 0 { 60 } else { ttl };
         let pnr_zone = PnrZone::new(
             name.clone(),
-            vec![PnrRecord::new(Some("".to_string()), address.clone(), PnrRecordType::X, ttl_or_default)],
+            HashMap::from([("".to_string(), PnrRecord::new(address.clone(), PnrRecordType::X, ttl_or_default))]),
             None,
             None
         );

--- a/test/postman/anttp_postman_collection.json
+++ b/test/postman/anttp_postman_collection.json
@@ -836,7 +836,7 @@
 								],
 								"body": {
 									"mode": "raw",
-									"raw": "{\n    \"name\": \"test_pnr\",\n    \"records\": []\n}",
+									"raw": "{\n    \"name\": \"test_pnr\",\n    \"records\": {}\n}",
 									"options": {
 										"raw": {
 											"language": "json"
@@ -868,7 +868,7 @@
 								],
 								"body": {
 									"mode": "raw",
-									"raw": "{\n    \"name\": \"test_pnr\",\n    \"records\": []\n}",
+									"raw": "{\n    \"name\": \"test_pnr\",\n    \"records\": {}\n}",
 									"options": {
 										"raw": {
 											"language": "json"


### PR DESCRIPTION
Resolves #86

Changes:
- Changed `PnrZone.records` from `Vec<PnrRecord>` to `HashMap<String, PnrRecord>` where the key is the sub-name.
- Removed `sub_name` from `PnrRecord` as it is now used as the key in the records map.
- Updated `proto/pnr.proto` to reflect these changes in gRPC API.
- Updated `src/grpc/pnr_handler.rs` and `src/service/pointer_name_resolver.rs` to handle the new map-based records.
- Updated `Cargo.toml` to increment patch version to `0.23.26`.
- Updated Postman collection `test/postman/anttp_postman_collection.json` to use JSON objects for records instead of arrays.
- Added unit tests in `src/grpc/pnr_handler.rs` and updated existing tests in `src/service/pointer_name_resolver.rs`.
- Created spec file `spec/00086_store_pnr_zone_records_as_a_key_value_map_to_easily_resolve_a_sub_name_to_an_address.txt`.