### PR TITLE
Add support to append/replace PNR records to PNR Zone (#88)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1186,7 +1186,7 @@ dependencies = [
 
 [[package]]
 name = "anttp"
-version = "0.23.26"
+version = "0.23.27"
 dependencies = [
  "actix-files",
  "actix-http",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "anttp"
-version = "0.23.26"
+version = "0.23.27"
 edition = "2024"
 authors = ["Paul Green"]
 description = "AntTP is an HTTP server for the Autonomi Network"

--- a/spec/00088_add_support_to_append_replace_pnr_records_to_an_existing_pnr_zone_over_rest_api.txt
+++ b/spec/00088_add_support_to_append_replace_pnr_records_to_an_existing_pnr_zone_over_rest_api.txt
@@ -1,0 +1,27 @@
+As a REST API consumer
+I want to be able to easily add PNR records without having to retrieve/update them
+So that adding or replacing records becomes a trivial operation when using APIs
+
+Given that there is already support to create and update PNRs
+When adding support to append or replace PNR records for an existing zone
+Then when append_pnr is called in PnrService, then get_pnr and update_pnr should be used to retrieve/store the changes
+And if the record key already exists, the value should be replaced before the PNR Zone is persisted
+And multiple records can be added or replaced in the same operation
+
+Given that the REST API will need to be updated
+When adding append PNR record support
+Then provide a PATCH endpoint at /anttp-0/pnr/{name}
+And use put_pnr() on pnr_controller.rs as an example
+And update /src/lib.rs with the additional pnr/{name} route, using other routes as a guide
+And the request body should be the same as the put_pnr() operation, using PnrZone
+
+Given the postman collection has tests for PNR create/update
+When adding append PNR record support
+Then the postman collection should be updated
+And newman should be used to validate
+
+Implementation Notes
+
+- Place any unit tests at the bottom of the same file as the associated production code
+- Increment patch version of anttp package in Cargo.toml
+- Create a copy of this issue description and save to /spec using the name of this issue as the filename (with lower underscore case, starting with the 5 char padded issue number, e.g. 00001_issue_title.txt)

--- a/src/controller/pnr_controller.rs
+++ b/src/controller/pnr_controller.rs
@@ -66,6 +66,37 @@ pub async fn put_pnr(
 }
 
 #[utoipa::path(
+    patch,
+    path = "/anttp-0/pnr/{name}",
+    params(
+        ("name", description = "PNR name"),
+        ("x-store-type", Header, description = "Only persist to cache and do not publish (memory|disk|none)",
+        example = "memory"),
+    ),
+    request_body(
+        content = PnrZone
+    ),
+    responses(
+        (status = OK, description = "PNR zone records appended/replaced successfully", body = PnrZone),
+        (status = BAD_REQUEST, description = "PNR zone body was invalid")
+    ),
+)]
+pub async fn patch_pnr(
+    path: web::Path<String>,
+    pnr_service: Data<PnrService>,
+    evm_wallet_data: Data<EvmWallet>,
+    pnr_zone: web::Json<PnrZone>,
+    request: HttpRequest,
+) -> Result<HttpResponse, PointerError> {
+    let name = path.into_inner();
+
+    debug!("Appending PNR records to zone");
+    Ok(HttpResponse::Ok().json(
+        pnr_service.append_pnr(name, pnr_zone.into_inner(), evm_wallet_data.get_ref().clone(), get_store_type(&request)).await?
+    ))
+}
+
+#[utoipa::path(
     get,
     path = "/anttp-0/pnr/{name}",
     params(

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -106,7 +106,8 @@ pub async fn run_server(ant_tp_config: AntTpConfig) -> io::Result<()> {
         command_controller::get_commands,
         pnr_controller::get_pnr,
         pnr_controller::post_pnr,
-        pnr_controller::put_pnr
+        pnr_controller::put_pnr,
+        pnr_controller::patch_pnr
     ))]
     struct ApiDoc;
 
@@ -390,6 +391,10 @@ pub async fn run_server(ant_tp_config: AntTpConfig) -> io::Result<()> {
                 .route(
                     format!("{}pnr/{{name}}", API_BASE).as_str(),
                     web::put().to(pnr_controller::put_pnr)
+                )
+                .route(
+                    format!("{}pnr/{{name}}", API_BASE).as_str(),
+                    web::patch().to(pnr_controller::patch_pnr)
                 )
         };
 

--- a/test/postman/anttp_postman_collection.json
+++ b/test/postman/anttp_postman_collection.json
@@ -905,6 +905,39 @@
 									]
 								}
 							}
+						},
+						{
+							"name": "Append PNR",
+							"request": {
+								"method": "PATCH",
+								"header": [
+									{
+										"key": "x-store-type",
+										"value": "memory",
+										"type": "text"
+									}
+								],
+								"body": {
+									"mode": "raw",
+									"raw": "{\n    \"name\": \"test_pnr\",\n    \"records\": {\n        \"test\": {\n            \"address\": \"0x123\",\n            \"record_type\": \"X\",\n            \"ttl\": 60\n        }\n    }\n}",
+									"options": {
+										"raw": {
+											"language": "json"
+										}
+									}
+								},
+								"url": {
+									"raw": "{{base_url}}/anttp-0/pnr/test_pnr",
+									"host": [
+										"{{base_url}}"
+									],
+									"path": [
+										"anttp-0",
+										"pnr",
+										"test_pnr"
+									]
+								}
+							}
 						}
 					]
 				}


### PR DESCRIPTION
Resolves #88

This PR adds support to append or replace PNR records to an existing PNR Zone via the REST API.

Changes:
- Implemented `append_pnr` in `PnrService` which retrieves the existing PNR zone, updates its records, and persists the changes.
- Added a new `PATCH /anttp-0/pnr/{name}` endpoint in `pnr_controller.rs`.
- Registered the PATCH route in `src/lib.rs`.
- Added unit tests for the record merging logic in `pnr_service.rs`.
- Updated the Postman collection with an "Append PNR" request example.
- Incremented the patch version in `Cargo.toml` to `0.23.27`.
- Added a spec file for the issue in `spec/`.