### PR TITLE
feat(grpc): add get and list files support for public archive to gRPC

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1186,7 +1186,7 @@ dependencies = [
 
 [[package]]
 name = "anttp"
-version = "0.24.11"
+version = "0.24.12"
 dependencies = [
  "actix-files",
  "actix-http",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "anttp"
-version = "0.24.11"
+version = "0.24.12"
 edition = "2024"
 authors = ["Paul Green"]
 description = "AntTP is an HTTP server for the Autonomi Network"

--- a/proto/public_archive.proto
+++ b/proto/public_archive.proto
@@ -6,6 +6,7 @@ service PublicArchiveService {
   rpc CreatePublicArchive(CreatePublicArchiveRequest) returns (PublicArchiveResponse);
   rpc UpdatePublicArchive(UpdatePublicArchiveRequest) returns (PublicArchiveResponse);
   rpc TruncatePublicArchive(TruncatePublicArchiveRequest) returns (PublicArchiveResponse);
+  rpc GetPublicArchive(GetPublicArchiveRequest) returns (GetPublicArchiveResponse);
 }
 
 message File {
@@ -31,6 +32,18 @@ message TruncatePublicArchiveRequest {
   optional string store_type = 3;
 }
 
+message GetPublicArchiveRequest {
+  string address = 1;
+  string path = 2;
+  optional string store_type = 3;
+}
+
 message PublicArchiveResponse {
   optional string address = 1;
+}
+
+message GetPublicArchiveResponse {
+  optional string address = 1;
+  repeated string items = 2;
+  optional bytes content = 3;
 }

--- a/spec/00116_add_get_and_list_files_support_for_public_archive_to_grpc.txt
+++ b/spec/00116_add_get_and_list_files_support_for_public_archive_to_grpc.txt
@@ -1,0 +1,60 @@
+As a software engineer
+I want to provide a get and list files for public archives over gRPC
+So that I can can also use the gRPC endpoint to get/list files
+
+Given  GET /anttp-0/public_archive/{address}/{*path} endpoint is already supported in public_archive_controller.rs
+When get or list files over gRPC
+Then use public_archive_controller.rs as an example
+And use get_public_data in public_data_handler.rs as an example gRPC endpoint
+
+Given public_archive_service.rs has get_public_archive that returns base64 encoded content
+When calling via gRPC handler
+Then provide an additional parameter to return the raw bytes in the payload (instead of base64 encoded string)
+And return PublicArchiveRaw (see examples below) instead, with content being Bytes instead of String
+And then gRPC proto can contain the raw bytes
+
+Given a {*path} can be a directory or a file
+When the path is a file
+Then return the content as a protobuf containing a content field (for content), address field (for archive address), and an empty items list field
+And see example proto file below
+
+Given a {*path} can be a directory or a file
+When the path is a directory
+Then return the content as a protobuf containing an items field, with a list of the files in that directory, address field (for archive address), and an empty content field
+And see example proto file below
+
+Implementation Notes
+
+- Place any unit tests at the bottom of the same file as the associated production code
+- Increment patch version of anttp package in Cargo.toml
+- Create a copy of this issue description and save to /spec using the name of this issue as the filename (with lower underscore case, starting with the 5 char padded issue number, e.g. 00001_issue_title.txt)
+- Do not attempt to clone or mock *_service.rs code
+
+Example proto responses for file:
+
+```
+rpc GetPublicArchive(GetPublicArchiveRequest) returns (PublicArchiveResponse);
+
+message TruncatePublicArchiveRequest {
+  string address = 1;
+  string path = 2;
+  optional string store_type = 3;
+}
+
+message PublicArchiveResponse {
+  optional string address = 1;
+  repeated string items = 2;
+  optional bytes content = 3;
+}
+```
+
+PublicArchiveRaw:
+
+```
+#[derive(Serialize, Deserialize, ToSchema, Debug, Clone, PartialEq)]
+pub struct PublicArchiveResponse {
+    pub items: Vec<String>,
+    pub content: Bytes,
+    pub address: String,
+}
+```


### PR DESCRIPTION
Resolves #116

This PR adds support for getting and listing files in public archives via gRPC.

Changes:
- Modified `PublicArchiveService` to provide `get_public_archive_binary` for raw byte retrieval.
- Updated `public_archive.proto` with `GetPublicArchive` RPC.
- Implemented `GetPublicArchive` in `PublicArchiveHandler`.
- Added unit tests for gRPC response mapping in `public_archive_handler.rs`.
- Incremented patch version to `0.24.12` in `Cargo.toml`.
- Added spec file for the issue.