### PR TITLE
Update public_archive and tarchive gRPC handlers to support path and store_type (Issue #123)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1186,7 +1186,7 @@ dependencies = [
 
 [[package]]
 name = "anttp"
-version = "0.24.14"
+version = "0.24.15"
 dependencies = [
  "actix-files",
  "actix-http",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "anttp"
-version = "0.24.14"
+version = "0.24.15"
 edition = "2024"
 authors = ["Paul Green"]
 description = "AntTP is an HTTP server for the Autonomi Network"

--- a/proto/public_archive.proto
+++ b/proto/public_archive.proto
@@ -12,18 +12,19 @@ service PublicArchiveService {
 message File {
   string name = 1;
   bytes content = 2;
-  optional string target_path = 3;
 }
 
 message CreatePublicArchiveRequest {
   repeated File files = 1;
-  optional string store_type = 2;
+  optional string path = 2;
+  optional string store_type = 3;
 }
 
 message UpdatePublicArchiveRequest {
   string address = 1;
   repeated File files = 2;
-  optional string store_type = 3;
+  optional string path = 3;
+  optional string store_type = 4;
 }
 
 message TruncatePublicArchiveRequest {

--- a/proto/tarchive.proto
+++ b/proto/tarchive.proto
@@ -10,18 +10,19 @@ service TarchiveService {
 message File {
   string name = 1;
   bytes content = 2;
-  optional string target_path = 3;
 }
 
 message CreateTarchiveRequest {
   repeated File files = 1;
-  optional string store_type = 2;
+  optional string path = 2;
+  optional string store_type = 3;
 }
 
 message UpdateTarchiveRequest {
   string address = 1;
   repeated File files = 2;
-  optional string store_type = 3;
+  optional string path = 3;
+  optional string store_type = 4;
 }
 
 message TarchiveResponse {

--- a/spec/00123_update_public_archive_handler_tarchive_handler_so_that_it_correctly_sets_the_path_when_creating_updating_files.txt
+++ b/spec/00123_update_public_archive_handler_tarchive_handler_so_that_it_correctly_sets_the_path_when_creating_updating_files.txt
@@ -1,0 +1,38 @@
+As a public archive and tarchive gRPC API consumer
+I want to provide a single path value along with a selection of files during create/update
+So that gRPC better aligns with REST and the interface becomes simpler
+
+Given create/update /anttp-0/public_archive/{address}/{*path} endpoints are already supported in public_archive_controller.rs
+When defining protos (and handlers) for create/update operations
+Then public_archive_handler.rs and tarchive_handler.rs should more closely follow the same structure (see example proto below)
+And it allows the same public_archive_service.rs and tarchive_service.rs code to be shared
+And it still allows batches of files to be uploaded at once (for files in the same directory)
+
+Implementation Notes
+
+- Place any unit tests at the bottom of the same file as the associated production code
+- Increment patch version of anttp package in Cargo.toml
+- Create a copy of this issue description and save to /spec using the name of this issue as the filename (with lower underscore case, starting with the 5 char padded issue number, e.g. 00001_issue_title.txt)
+- Do not attempt to clone or mock *_service.rs code
+
+Example proto responses for file:
+
+```
+message File {
+  string name = 1;
+  bytes content = 2;
+}
+
+message CreatePublicArchiveRequest {
+  repeated File files = 1;
+  optional string path = 2;
+  optional string store_type = 3;
+}
+
+message UpdatePublicArchiveRequest {
+  string address = 1;
+  repeated File files = 2;
+  optional string path = 3;
+  optional string store_type = 4;
+}
+```

--- a/src/grpc/public_archive_handler.rs
+++ b/src/grpc/public_archive_handler.rs
@@ -79,7 +79,7 @@ impl PublicArchiveServiceTrait for PublicArchiveHandler {
         let public_archive_form = self.map_to_multipart_form(req.files)?;
         
         let result = self.public_archive_service.create_public_archive(
-            None,
+            req.path,
             public_archive_form,
             self.evm_wallet.get_ref().clone(),
             StoreType::from(req.store_type.unwrap_or_default())
@@ -97,7 +97,7 @@ impl PublicArchiveServiceTrait for PublicArchiveHandler {
         
         let result = self.public_archive_service.update_public_archive(
             req.address,
-            None,
+            req.path,
             public_archive_form,
             self.evm_wallet.get_ref().clone(),
             StoreType::from(req.store_type.unwrap_or_default())

--- a/src/grpc/tarchive_handler.rs
+++ b/src/grpc/tarchive_handler.rs
@@ -72,7 +72,7 @@ impl TarchiveServiceTrait for TarchiveHandler {
         let tarchive_form = self.map_to_multipart_form(req.files)?;
         
         let result = self.tarchive_service.create_tarchive(
-            None,
+            req.path,
             tarchive_form,
             self.evm_wallet.get_ref().clone(),
             StoreType::from(req.store_type.unwrap_or_default())
@@ -90,7 +90,7 @@ impl TarchiveServiceTrait for TarchiveHandler {
         
         let result = self.tarchive_service.update_tarchive(
             req.address,
-            None,
+            req.path,
             tarchive_form,
             self.evm_wallet.get_ref().clone(),
             StoreType::from(req.store_type.unwrap_or_default())


### PR DESCRIPTION
Resolves issue #123.

Changes:
- Updated `proto/public_archive.proto` and `proto/tarchive.proto` to include `path` and `store_type` in `Create/Update` requests.
- Removed `target_path` from `File` message in both protos to align with REST API.
- Updated `src/grpc/public_archive_handler.rs` and `src/grpc/tarchive_handler.rs` to pass the `path` and `store_type` from gRPC requests to the respective services.
- Saved issue description to `spec/00123_update_public_archive_handler_tarchive_handler_so_that_it_correctly_sets_the_path_when_creating_updating_files.txt`.
- Incremented package version in `Cargo.toml` to `0.24.15`.
- Verified changes with unit tests.