### PR TITLE
Implement push_archive for tarchive #147

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1186,7 +1186,7 @@ dependencies = [
 
 [[package]]
 name = "anttp"
-version = "0.24.23"
+version = "0.24.24"
 dependencies = [
  "actix-files",
  "actix-http",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "anttp"
-version = "0.24.23"
+version = "0.24.24"
 edition = "2024"
 authors = ["Paul Green"]
 description = "AntTP is an HTTP server for the Autonomi Network"

--- a/spec/00147_implement_push_archive_for_tarchive.txt
+++ b/spec/00147_implement_push_archive_for_tarchive.txt
@@ -1,0 +1,19 @@
+As an archive API consumer
+I want to be able to push tarchives to a target store-type
+So that the archive API has full support for both public archives and archives
+
+Given public_archive_service.rs already implements push_public_archive
+When adding push support for tarchives
+Then add push_tarchive function to tarchive_service.rs with the same signature as public_archive_service.rs
+And call public_data_service.push_public_data() to push the data
+
+Given tarchive_controller.rs already calls public_data_service.push_public_data directly
+When adding push support to tarchive_service.rs
+Then update tarchive_controller.rs to call push_tarchive in tarchive_service.rs instead
+And use tarchive_controller.rs push_archive as an example of how to call public_data_service.push_public_data 
+
+Implementation Notes
+
+- Place any unit tests at the bottom of the same file as the associated production code
+- Increment patch version of anttp package in Cargo.toml
+- Create a copy of this issue description and save to /spec using the name of this issue as the filename (with lower underscore case, starting with the 5 char padded issue number, e.g. 00001_issue_title.txt)

--- a/src/controller/tarchive_controller.rs
+++ b/src/controller/tarchive_controller.rs
@@ -5,7 +5,6 @@ use ant_evm::EvmWallet;
 use log::debug;
 use crate::service::public_archive_service::{PublicArchiveForm, Upload, ArchiveResponse};
 use crate::service::tarchive_service::TarchiveService;
-use crate::service::public_data_service::PublicDataService;
 use crate::error::tarchive_error::TarchiveError;
 use crate::controller::get_store_type;
 
@@ -51,7 +50,7 @@ pub async fn delete_tarchive(
 )]
 pub async fn push_tarchive(
     path: web::Path<String>,
-    public_data_service: Data<PublicDataService>,
+    tarchive_service: Data<TarchiveService>,
     evm_wallet_data: Data<EvmWallet>,
     request: HttpRequest,
 ) -> Result<HttpResponse, TarchiveError> {
@@ -60,7 +59,7 @@ pub async fn push_tarchive(
 
     debug!("Pushing tarchive [{}] to target store type [{:?}]", address, get_store_type(&request));
     Ok(HttpResponse::Ok().json(
-        public_data_service.push_public_data(address, evm_wallet, get_store_type(&request)).await?
+        tarchive_service.push_tarchive(address, evm_wallet, get_store_type(&request)).await?
     ))
 }
 

--- a/src/service/archive_service.rs
+++ b/src/service/archive_service.rs
@@ -146,9 +146,7 @@ impl ArchiveService {
         let archive = self.archive_caching_client.archive_get(archive_address).await?;
         match archive.archive_type {
             ArchiveType::Public => self.public_archive_service.push_public_archive(address, wallet, store_type).await.map(|u| Upload { address: u.address }).map_err(ArchiveError::from),
-            ArchiveType::Tarchive => {
-                 Err(ArchiveError::NotImplemented("Push for Tarchive not yet implemented in ArchiveService".to_string()))
-            }
+            ArchiveType::Tarchive => self.tarchive_service.push_tarchive(address, wallet, store_type).await.map(|u| Upload { address: u.address }).map_err(ArchiveError::from),
         }
     }
 


### PR DESCRIPTION
Resolves #147

This PR implements `push_archive` support for Tarchives.

Changes:
- Added `push_tarchive` function to `TarchiveService` in `src/service/tarchive_service.rs` which calls `public_data_service.push_public_data()`.
- Updated `push_tarchive` in `src/controller/tarchive_controller.rs` to call the new service function.
- Updated `push_archive` in `src/service/archive_service.rs` to use `tarchive_service.push_tarchive` instead of returning a `NotImplemented` error.
- Incremented the patch version of `anttp` to `0.24.24` in `Cargo.toml`.
- Created a spec file `spec/00147_implement_push_archive_for_tarchive.txt`.
- Added a unit test `test_push_tarchive_success` in `src/service/tarchive_service.rs`.
- Removed unused `PublicDataService` import from `tarchive_controller.rs`.