### PR TITLE
feat(archive): resolve names/addresses in ArchiveService before operations (closes #150)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1186,7 +1186,7 @@ dependencies = [
 
 [[package]]
 name = "anttp"
-version = "0.25.0"
+version = "0.25.1"
 dependencies = [
  "actix-files",
  "actix-http",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "anttp"
-version = "0.25.0"
+version = "0.25.1"
 edition = "2024"
 authors = ["Paul Green"]
 description = "AntTP is an HTTP server for the Autonomi Network"

--- a/spec/00150_add_name_address_resolving_to_the_archive_endpoints.txt
+++ b/spec/00150_add_name_address_resolving_to_the_archive_endpoints.txt
@@ -1,0 +1,17 @@
+As an archive API consumer
+I want to be able to provide the unresolved name or address to the archive endpoints
+So that I can easily interact with the archive endpoints without having to resolve the target address beforehand
+
+Given the 'resolve_name' function in resolver_service.rs can accept any source name or address as an input and output the target address
+When any public function in archive_service.rs is called with an 'address' argument
+Then include ResolverService in the ArchiveService struct
+And update code that instantiates ArchiveService to provide Resolver service as a dependency
+And firstly call the 'resolve' function in resolver_service.rs and attempt to resolve the address
+And use the resolved address, instead of the original address, for the rest of the function 
+
+Implementation Notes
+
+- Place any unit tests at the bottom of the same file as the associated production code
+- Increment patch version of anttp package in Cargo.toml
+- Create a copy of this issue description and save to /spec using the name of this issue as the filename (with lower underscore case, starting with the 5 char padded issue number, e.g. 00001_issue_title.txt)
+- Update unit tests to validate the changes

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -238,7 +238,12 @@ pub async fn run_server(ant_tp_config: AntTpConfig) -> io::Result<()> {
     let public_data_service_data = Data::new(PublicDataService::new(public_data_caching_client.clone()));
     let register_service_data = Data::new(RegisterService::new(register_caching_client.clone(), ant_tp_config.clone(), resolver_service_data.get_ref().clone()));
     let scratchpad_service_data = Data::new(ScratchpadService::new(scratchpad_caching_client.clone(), ant_tp_config.clone()));
-    let archive_service_data = Data::new(ArchiveService::new(public_archive_service_data.get_ref().clone(), tarchive_service_data.get_ref().clone(), archive_caching_client.clone()));
+    let archive_service_data = Data::new(ArchiveService::new(
+        public_archive_service_data.get_ref().clone(),
+        tarchive_service_data.get_ref().clone(),
+        resolver_service_data.get_ref().clone(),
+        archive_caching_client.clone()
+    ));
     let pnr_service_data = Data::new(PnrService::new(chunk_caching_client.clone(), pointer_service_data.clone()));
     let key_value_service_data = Data::new(KeyValueService::new(public_data_service_data.clone(), pnr_service_data.clone()));
 


### PR DESCRIPTION
Implements issue #150: Add name/address resolving to the archive endpoints

Summary
- Inject `ResolverService` into `ArchiveService`
- Resolve provided `address` via `ResolverService::resolve_name` before any archive operation: `get_archive`, `get_archive_binary`, `update_archive`, `truncate_archive`, `push_archive`
- Wire up `ResolverService` in `src/lib.rs` when constructing `ArchiveService`
- Bump patch version in `Cargo.toml` to 0.25.1
- Add spec file: `spec/00150_add_name_address_resolving_to_the_archive_endpoints.txt`

Testing
- `cargo build` successful
- `cargo test` all tests passing (147 passed)

Notes
- Behavior: If name resolution returns `None`, original `address` is used (backward compatible). Hex parsing errors will surface as before if `address` is invalid.

Closes #150.