### PR TITLE
Implement name/address resolution for chunk endpoints (#153)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1186,7 +1186,7 @@ dependencies = [
 
 [[package]]
 name = "anttp"
-version = "0.25.1"
+version = "0.25.2"
 dependencies = [
  "actix-files",
  "actix-http",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "anttp"
-version = "0.25.1"
+version = "0.25.2"
 edition = "2024"
 authors = ["Paul Green"]
 description = "AntTP is an HTTP server for the Autonomi Network"

--- a/spec/00153_add_name_address_resolving_to_the_chunk_endpoints.txt
+++ b/spec/00153_add_name_address_resolving_to_the_chunk_endpoints.txt
@@ -1,0 +1,17 @@
+As an chunk API consumer
+I want to be able to provide the unresolved name or address to the chunk endpoints
+So that I can easily interact with the chunk endpoints without having to resolve the target address beforehand
+
+Given the &#39;resolve_name&#39; function in resolver_service.rs can accept any source name or address as an input and output the target address
+When get_chunk_binary or get_chunk functions in chunk_service.rs are called with an &#39;address&#39; argument
+Then include ResolverService in the ChunkService struct
+And update code that instantiates ChunkService to provide Resolver service as a dependency
+And firstly call the &#39;resolve_name&#39; function in resolver_service.rs and attempt to resolve the address
+And use the resolved address, instead of the original address, for the rest of the function 
+
+Implementation Notes
+
+- Place any unit tests at the bottom of the same file as the associated production code
+- Increment patch version of anttp package in Cargo.toml
+- Create a copy of this issue description and save to /spec using the name of this issue as the filename (with lower underscore case, starting with the 5 char padded issue number, e.g. 00001_issue_title.txt)
+- Update unit tests to validate the changes

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -232,7 +232,7 @@ pub async fn run_server(ant_tp_config: AntTpConfig) -> io::Result<()> {
         FileService::new(chunk_caching_client.clone(), ant_tp_config.download_threads)
     ));
     let command_service_data = Data::new(CommandService::new(command_status_data.clone()));
-    let chunk_service_data = Data::new(ChunkService::new(chunk_caching_client.clone()));
+    let chunk_service_data = Data::new(ChunkService::new(chunk_caching_client.clone(), resolver_service_data.get_ref().clone()));
     let graph_service_data = Data::new(GraphService::new(graph_entry_caching_client.clone(), ant_tp_config.clone()));
     let pointer_service_data = Data::new(PointerService::new(pointer_caching_client.clone(), ant_tp_config.clone(), resolver_service_data.get_ref().clone()));
     let public_data_service_data = Data::new(PublicDataService::new(public_data_caching_client.clone()));


### PR DESCRIPTION
Resolves issue #153.
Adds name and address resolution to the chunk endpoints.
The `ChunkService` now includes `ResolverService` as a dependency and calls `resolve_name` before processing the provided address.
Updated `Cargo.toml` patch version to 0.25.2.
Created spec file `/spec/00153_add_name_address_resolving_to_the_chunk_endpoints.txt`.
Added unit tests to validate name resolution in `get_chunk` and `get_chunk_binary`.