### PR TITLE
feat(api): create resolver REST endpoint #149

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "anttp"
-version = "0.25.2"
+version = "0.25.3"
 edition = "2024"
 authors = ["Paul Green"]
 description = "AntTP is an HTTP server for the Autonomi Network"

--- a/spec/00149_create_resolver_rest_endpoint_to_accept_a_name_address_and_return_the_fully_resolved_address.txt
+++ b/spec/00149_create_resolver_rest_endpoint_to_accept_a_name_address_and_return_the_fully_resolved_address.txt
@@ -1,0 +1,26 @@
+As a REST API consumer
+I want to be able to resolve a source name or address from a resolver endpoint
+So that I can easily discover a target address without knowing additional details about the source name/address
+
+Given pointer_controller.rs already exist and define a similar pattern
+When adding the resolver REST endpoint
+Then add /src/controller/resolver_controller.rs based on /scr/controller/pointer_controller.rs
+And only add a function called 'resolve' similar to the get_pointer function, but without the PointerError requirement
+And the endpoint should be GET /anttp-0/resolve/{name}, where {name} can be a source name or address
+And the endpoint will only return a successful 200 response with the resolved target address or a 404 if it could not be found
+And update the utoipa annotation to reflect the above
+
+Given the 'resolve' function in resolver_service.rs can accept any source name or address as an input and output the target address
+When adding the resolver endpoint
+Then ensure the 'resolve' function in resolve_controller.rs accepts `resolver_service: Data` as an argument
+And calls the 'resolve_name' function in resolver_service.rs and attempt to resolve the address
+And returns the resolved target address to the consumer
+And update /src/lib.rs utoipa annotation to include the new controller and endpoint
+And add a route to resolve in resolver_controller.rs
+
+Implementation Notes
+
+- Place any unit tests at the bottom of the same file as the associated production code
+- Increment patch version of anttp package in Cargo.toml
+- Create a copy of this issue description and save to /spec using the name of this issue as the filename (with lower underscore case, starting with the 5 char padded issue number, e.g. 00149_issue_title.txt)
+- Update unit tests to reflect the above

--- a/src/controller/mod.rs
+++ b/src/controller/mod.rs
@@ -15,6 +15,7 @@ pub mod command_controller;
 pub mod connect_controller;
 pub mod pnr_controller;
 pub mod key_value_controller;
+pub mod resolver_controller;
 
 #[derive(Clone,Debug)]
 pub enum StoreType {

--- a/src/controller/resolver_controller.rs
+++ b/src/controller/resolver_controller.rs
@@ -1,0 +1,28 @@
+use actix_web::{web, HttpResponse};
+use actix_web::web::Data;
+use log::debug;
+use crate::service::resolver_service::ResolverService;
+
+#[utoipa::path(
+    get,
+    path = "/anttp-0/resolve/{name}",
+    params(
+        ("name" = String, Path, description = "Source name or address to resolve"),
+    ),
+    responses(
+        (status = OK, description = "Address resolved successfully", body = String),
+        (status = NOT_FOUND, description = "Address could not be found")
+    )
+)]
+pub async fn resolve(
+    path: web::Path<String>,
+    resolver_service: Data<ResolverService>,
+) -> HttpResponse {
+    let name = path.into_inner();
+    debug!("Resolving name [{}]", name);
+
+    match resolver_service.resolve_name(&name).await {
+        Some(resolved_address) => HttpResponse::Ok().json(resolved_address),
+        None => HttpResponse::NotFound().finish(),
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -159,7 +159,8 @@ pub async fn run_server(ant_tp_config: AntTpConfig) -> io::Result<()> {
             pnr_controller::put_pnr,
             pnr_controller::patch_pnr,
             key_value_controller::post_key_value,
-            key_value_controller::get_key_value
+            key_value_controller::get_key_value,
+            resolver_controller::resolve
         ),
         components(
             schemas(PublicArchiveForm, ArchiveForm, Upload, ArchiveResponse, Chunk, ArchiveType)
@@ -391,6 +392,10 @@ pub async fn run_server(ant_tp_config: AntTpConfig) -> io::Result<()> {
             .route(
                 format!("{}key_value/{{bucket}}/{{object}}", API_BASE).as_str(),
                 web::get().to(key_value_controller::get_key_value)
+            )
+            .route(
+                format!("{}resolve/{{name}}", API_BASE).as_str(),
+                web::get().to(resolver_controller::resolve)
             )
             .route(
                 format!("{}archive/{{address}}", API_BASE).as_str(),


### PR DESCRIPTION
Resolves #149

This PR adds a new REST endpoint `GET /anttp-0/resolve/{name}` to resolve source names or addresses (bookmarks or PNR names) to their target addresses on the Autonomi Network.

Changes:
- Created `src/controller/resolver_controller.rs` with the `resolve` endpoint.
- Registered the new controller and route in `src/lib.rs`.
- Included the new endpoint in `utoipa` API documentation.
- Incremented `anttp` package version to `0.25.3`.
- Added spec file `spec/00149_create_resolver_rest_endpoint_to_accept_a_name_address_and_return_the_fully_resolved_address.txt`.