### PR TITLE
feat(155): resolve name and address in public data endpoints

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1186,7 +1186,7 @@ dependencies = [
 
 [[package]]
 name = "anttp"
-version = "0.25.2"
+version = "0.25.3"
 dependencies = [
  "actix-files",
  "actix-http",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "anttp"
-version = "0.25.2"
+version = "0.25.3"
 edition = "2024"
 authors = ["Paul Green"]
 description = "AntTP is an HTTP server for the Autonomi Network"

--- a/spec/00155_add_name_address_resolving_to_the_public_data_endpoints.txt
+++ b/spec/00155_add_name_address_resolving_to_the_public_data_endpoints.txt
@@ -1,0 +1,18 @@
+As an public data API consumer
+I want to be able to provide the unresolved name or address to the chunk endpoints
+So that I can easily interact with the chunk endpoints without having to resolve the target address beforehand
+
+Given the 'resolve_name' function in resolver_service.rs can accept any source name or address as an input and output the target address
+When push_public_data or get_public_data_binary functions in public_data_service.rs are called with an 'address' argument
+Then include ResolverService in the PublicDataService struct
+And update code that instantiates PublicDataService to provide Resolver service as a dependency
+And firstly call the 'resolve_name' function in resolver_service.rs and attempt to resolve the address
+And use the resolved address, instead of the original address, for the rest of the function 
+
+Implementation Notes
+
+- Place any unit tests at the bottom of the same file as the associated production code
+- Increment patch version of anttp package in Cargo.toml
+- Create a copy of this issue description and save to /spec using the name of this issue as the filename (with lower underscore case, starting with the 5 char padded issue number, e.g. 00001_issue_title.txt)
+- Update unit tests to validate the changes
+- Do NOT create any new mocks

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -227,7 +227,7 @@ pub async fn run_server(ant_tp_config: AntTpConfig) -> io::Result<()> {
     // define services
     let public_archive_service_data = Data::new(PublicArchiveService::new(FileService::new(chunk_caching_client.clone(), ant_tp_config.download_threads), public_archive_caching_client.clone(), public_data_caching_client.clone()));
     let tarchive_service_data = Data::new(TarchiveService::new(
-        PublicDataService::new(public_data_caching_client.clone()),
+        PublicDataService::new(public_data_caching_client.clone(), resolver_service_data.get_ref().clone()),
         tarchive_caching_client.clone(),
         FileService::new(chunk_caching_client.clone(), ant_tp_config.download_threads)
     ));
@@ -235,7 +235,7 @@ pub async fn run_server(ant_tp_config: AntTpConfig) -> io::Result<()> {
     let chunk_service_data = Data::new(ChunkService::new(chunk_caching_client.clone(), resolver_service_data.get_ref().clone()));
     let graph_service_data = Data::new(GraphService::new(graph_entry_caching_client.clone(), ant_tp_config.clone()));
     let pointer_service_data = Data::new(PointerService::new(pointer_caching_client.clone(), ant_tp_config.clone(), resolver_service_data.get_ref().clone()));
-    let public_data_service_data = Data::new(PublicDataService::new(public_data_caching_client.clone()));
+    let public_data_service_data = Data::new(PublicDataService::new(public_data_caching_client.clone(), resolver_service_data.get_ref().clone()));
     let register_service_data = Data::new(RegisterService::new(register_caching_client.clone(), ant_tp_config.clone(), resolver_service_data.get_ref().clone()));
     let scratchpad_service_data = Data::new(ScratchpadService::new(scratchpad_caching_client.clone(), ant_tp_config.clone()));
     let archive_service_data = Data::new(ArchiveService::new(

--- a/src/service/tarchive_service.rs
+++ b/src/service/tarchive_service.rs
@@ -265,6 +265,7 @@ impl TarchiveService {
 mod tests {
     use super::*;
     use crate::client::{MockPublicDataCachingClient, MockChunkCachingClient, MockTArchiveCachingClient};
+    use crate::service::resolver_service::MockResolverService;
     use autonomi::data::DataAddress;
     use xor_name::XorName;
     
@@ -272,6 +273,10 @@ mod tests {
         let mut mock_client = MockPublicDataCachingClient::default();
         let mut mock_chunk_client = MockChunkCachingClient::default();
         let mut mock_tarchive_client = MockTArchiveCachingClient::default();
+        let mut mock_resolver = MockResolverService::default();
+
+        mock_resolver.expect_resolve_name()
+            .returning(|address| Some(address.clone()));
 
         // Mock get_public_data_binary
         mock_client.expect_data_get_public()
@@ -284,7 +289,7 @@ mod tests {
         mock_tarchive_client.expect_get_archive_from_tar()
             .returning(|_| Ok(Bytes::from(vec![])));
 
-        let public_data_service = PublicDataService::new(mock_client);
+        let public_data_service = PublicDataService::new(mock_client, mock_resolver);
         let file_service = FileService::new(mock_chunk_client, 1);
         TarchiveService::new(public_data_service, mock_tarchive_client, file_service)
     }
@@ -325,7 +330,11 @@ mod tests {
         mock_client.expect_data_put_public()
             .returning(|_, _, _| Ok(DataAddress::new(XorName([0; 32]))));
 
-        let public_data_service = PublicDataService::new(mock_client);
+        let mut mock_resolver = MockResolverService::default();
+        mock_resolver.expect_resolve_name()
+            .returning(|address| Some(address.clone()));
+
+        let public_data_service = PublicDataService::new(mock_client, mock_resolver);
         let mock_chunk_client = MockChunkCachingClient::default();
         let mock_tarchive_client = MockTArchiveCachingClient::default();
         let file_service = FileService::new(mock_chunk_client, 1);
@@ -351,7 +360,11 @@ mod tests {
         mock_tarchive_client.expect_get_archive_from_tar()
             .returning(move |_| Ok(Bytes::from(index_data)));
 
-        let public_data_service = PublicDataService::new(mock_client);
+        let mut mock_resolver = MockResolverService::default();
+        mock_resolver.expect_resolve_name()
+            .returning(|address| Some(address.clone()));
+
+        let public_data_service = PublicDataService::new(mock_client, mock_resolver);
         let file_service = FileService::new(mock_chunk_client, 1);
         let service = TarchiveService::new(public_data_service, mock_tarchive_client, file_service);
 
@@ -384,7 +397,11 @@ mod tests {
             .expect_data_put_public()
             .returning(move |_, _, _| Ok(data_address));
 
-        let public_data_service = PublicDataService::new(mock_client);
+        let mut mock_resolver = MockResolverService::default();
+        mock_resolver.expect_resolve_name()
+            .returning(|address| Some(address.clone()));
+
+        let public_data_service = PublicDataService::new(mock_client, mock_resolver);
         let mock_chunk_client = MockChunkCachingClient::default();
         let mock_tarchive_client = MockTArchiveCachingClient::default();
         let file_service = FileService::new(mock_chunk_client, 1);
@@ -424,7 +441,11 @@ mod tests {
                 m
             });
 
-        let public_data_service = PublicDataService::new(mock_client);
+        let mut mock_resolver = MockResolverService::default();
+        mock_resolver.expect_resolve_name()
+            .returning(|address| Some(address.clone()));
+
+        let public_data_service = PublicDataService::new(mock_client, mock_resolver);
         let file_service = FileService::new(mock_chunk_client, 1);
         let service = TarchiveService::new(public_data_service, mock_tarchive_client, file_service);
 


### PR DESCRIPTION
Resolves issue #155.

This PR adds name and address resolution to the public data endpoints in `PublicDataService`.

### Changes:
- **`PublicDataService`**: Updated to include `ResolverService` as a dependency.
- **Resolution**: `push_public_data` and `get_public_data_binary` now call `resolver_service.resolve_name(address).await` before using the address.
- **Tests**: Updated unit tests for `PublicDataService` and `TarchiveService` to mock the resolution logic.
- **Integration**: Updated `lib.rs` to pass the `ResolverService` dependency.
- **Version**: Bumped patch version to `0.25.3`.
- **Spec**: Added a spec file at `spec/00155_add_name_address_resolving_to_the_public_data_endpoints.txt`.

Verified with `cargo test` and `cargo build`.