### PR TITLE
Add gRPC API function to allow individual PNR Records to be added/updated on a PNR Zone

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1186,7 +1186,7 @@ dependencies = [
 
 [[package]]
 name = "anttp"
-version = "0.25.5"
+version = "0.25.6"
 dependencies = [
  "actix-files",
  "actix-http",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "anttp"
-version = "0.25.5"
+version = "0.25.6"
 edition = "2024"
 authors = ["Paul Green"]
 description = "AntTP is an HTTP server for the Autonomi Network"

--- a/proto/pnr.proto
+++ b/proto/pnr.proto
@@ -5,6 +5,7 @@ package pnr;
 service PnrService {
   rpc CreatePnr(CreatePnrRequest) returns (PnrResponse);
   rpc UpdatePnr(UpdatePnrRequest) returns (PnrResponse);
+  rpc UpdatePnrRecord(UpdatePnrRecordRequest) returns (PnrResponse);
   rpc GetPnr(GetPnrRequest) returns (PnrResponse);
 }
 
@@ -35,6 +36,13 @@ message UpdatePnrRequest {
   string name = 1;
   PnrZone pnr_zone = 2;
   optional string store_type = 3;
+}
+
+message UpdatePnrRecordRequest {
+  string name = 1;
+  string record = 2;
+  PnrRecord pnr_record = 3;
+  optional string store_type = 4;
 }
 
 message GetPnrRequest {

--- a/spec/00169_add_grpc_api_function_to_allow_individual_pnr_records_to_be_added_updated_on_a_pnr_zone.txt
+++ b/spec/00169_add_grpc_api_function_to_allow_individual_pnr_records_to_be_added_updated_on_a_pnr_zone.txt
@@ -1,0 +1,31 @@
+As a PNR gRPC API consumer
+I want to be able to easily add or update individual PNR Records within a PNR Zone
+So that I don't have to provide a full PNR Record with all the PNR zones every time I make a modification
+
+Given pnr_handler.rs provides PNR operations
+When adding or updating a PNR Record
+Then add an UpdatePnrRecord RPC to add or update PNR Records (with key {record}) on an existing PNR Zone (with key {name})
+And update pnr.proto in a similar way to the example below:
+
+```
+rpc UpdatePnrRecord(UpdatePnrRecordRequest) returns (PnrResponse);
+
+message UpdatePnrRecordRequest {
+  string name = 1;
+  string record = 2;
+  PnrRecord pnr_record = 3;
+  optional string store_type = 4;
+}
+```
+
+Given pnr_service.rs performs changes to PNR zones and records
+When adding an PNR record to an existing PNR zone
+Then use update_pnr_record function in pnr_service.rs to add/update the PNR record
+
+Implementation Notes
+
+- Place any unit tests at the bottom of the same file as the associated production code
+- Increment patch version of anttp package in Cargo.toml
+- Create a copy of this issue description and save to /spec using the name of this issue as the filename (with lower underscore case, starting with the 5 char padded issue number, e.g. 00001_issue_title.txt)
+- Update unit tests to validate the changes
+- Update lib.rs with the new PNR function if needed


### PR DESCRIPTION
Resolves #169

Implemented the `UpdatePnrRecord` gRPC method to allow adding or updating individual PNR records within a PNR Zone.

Changes:
- Added `UpdatePnrRecord` RPC and `UpdatePnrRecordRequest` to `proto/pnr.proto`.
- Implemented `UpdatePnrRecord` in `src/grpc/pnr_handler.rs`, utilizing the existing `update_pnr_record` method in `PnrService`.
- Added unit tests for the new gRPC request mapping.
- Incremented patch version in `Cargo.toml` to `0.25.6`.
- Created spec file in `/spec/00169_add_grpc_api_function_to_allow_individual_pnr_records_to_be_added_updated_on_a_pnr_zone.txt`.