### PR TITLE
Add MCP API endpoint update_pnr_record #170

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "anttp"
-version = "0.25.6"
+version = "0.25.7"
 edition = "2024"
 authors = ["Paul Green"]
 description = "AntTP is an HTTP server for the Autonomi Network"

--- a/spec/00170_add_mcp_api_endpoint_to_allow_individual_pnr_records_to_be_added_updated_on_a_pnr_zone.txt
+++ b/spec/00170_add_mcp_api_endpoint_to_allow_individual_pnr_records_to_be_added_updated_on_a_pnr_zone.txt
@@ -1,0 +1,19 @@
+As a PNR MCP API consumer
+I want to be able to easily add or update individual PNR Records within a PNR Zone
+So that I don't have to provide a full PNR Record with all the PNR zones every time I make a modification
+
+Given pnr_tool.rs provides PNR operations
+When adding or updating a PNR Record
+Then add an update_pnr_record RPC to add or update PNR Records (with key {record}) on an existing PNR Zone (with key {name})
+
+Given pnr_service.rs performs changes to PNR zones and records
+When adding an PNR record to an existing PNR zone
+Then use update_pnr_record function in pnr_service.rs to add/update the PNR record
+
+Implementation Notes
+
+- Place any unit tests at the bottom of the same file as the associated production code
+- Increment patch version of anttp package in Cargo.toml
+- Create a copy of this issue description and save to /spec using the name of this issue as the filename (with lower underscore case, starting with the 5 char padded issue number, e.g. 00001_issue_title.txt)
+- Update unit tests to validate the changes
+- Update lib.rs with the new PNR function if needed


### PR DESCRIPTION
Resolves #170.

Added `update_pnr_record` MCP API endpoint to `src/tool/pnr_tool.rs` to allow adding or updating individual PNR records within an existing PNR zone.

Changes:
- Added `UpdatePnrRecordRequest` struct.
- Implemented `update_pnr_record` tool in `McpTool`.
- Added serialization test for `UpdatePnrRecordRequest`.
- Incremented patch version to `0.25.7`.
- Added issue description to `spec/`.