### PR TITLE
Add gRPC and MCP tools for key value endpoints (#176)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1186,7 +1186,7 @@ dependencies = [
 
 [[package]]
 name = "anttp"
-version = "0.25.8"
+version = "0.25.9"
 dependencies = [
  "actix-files",
  "actix-http",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "anttp"
-version = "0.25.8"
+version = "0.25.9"
 edition = "2024"
 authors = ["Paul Green"]
 description = "AntTP is an HTTP server for the Autonomi Network"

--- a/build.rs
+++ b/build.rs
@@ -21,6 +21,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
             tonic_build::compile_protos("proto/public_scratchpad.proto")?;
             tonic_build::compile_protos("proto/scratchpad.proto")?;
             tonic_build::compile_protos("proto/resolver.proto")?;
+            tonic_build::compile_protos("proto/key_value.proto")?;
         } else {
             println!("cargo:warning=protoc not found, disabling gRPC support");
             println!("cargo:rustc-cfg=grpc_disabled");

--- a/proto/key_value.proto
+++ b/proto/key_value.proto
@@ -1,0 +1,30 @@
+syntax = "proto3";
+
+package key_value;
+
+service KeyValueService {
+  rpc CreateKeyValue(CreateKeyValueRequest) returns (KeyValueResponse);
+  rpc GetKeyValue(GetKeyValueRequest) returns (GetKeyValueBinaryResponse);
+}
+
+message CreateKeyValueRequest {
+  string bucket = 1;
+  string object = 2;
+  bytes content = 3;
+}
+
+message GetKeyValueRequest {
+  string bucket = 1;
+  string object = 2;
+}
+
+message KeyValueResponse {
+  string bucket = 1;
+  string object = 2;
+}
+
+message GetKeyValueBinaryResponse {
+  string bucket = 1;
+  string object = 2;
+  bytes content = 3;
+}

--- a/spec/00176_add_grpc_and_mcp_tools_for_key_value_endpoints.txt
+++ b/spec/00176_add_grpc_and_mcp_tools_for_key_value_endpoints.txt
@@ -1,0 +1,56 @@
+As a gRPC and MCP API consumer
+I want to be call key/value endpoints in MCP and gRPC, like I can in REST
+So that I can easily create or retrieve a key/value with MCP/gRPC
+
+Given key_value_controller.rs already exists and interfaces with key_value_service.rs
+When adding key value support to gRPC and MCP
+When use key_value_controller.rs as an example of how to integrate with key_value_service.rs
+And refactor key_value_service.rs to provide functions for either base64 encoded content or binary content, re-using overlapping code
+And use the binary content oriented function with proto buffers (with key_value_handler.rs)
+
+Given pointer_handler.rs already exist
+When adding key_value_handler.rs
+Then use pointer_handler.rs and pointer_tool.rs as examples
+And integrate with key_value_service.rs
+And create/use the key_value.proto as defined below:
+
+
+```
+syntax = "proto3";
+
+package pointer;
+
+service PointerService {
+  rpc CreateKeyValue(CreateKeyValueRequest) returns (KeyValueResponse);
+  rpc GetKeyValue(GetKeyValueRequest) returns (KeyValueResponse);
+}
+
+message CreateKeyValueRequest {
+  string bucket = 1;
+  string object = 2;
+  bytes content = 3;
+}
+
+message GetKeyValueRequest {
+  string bucket = 1;
+  string object = 2;
+  bytes content = 3;
+}
+
+message KeyValueResponse {
+  string bucket = 1;
+  string object = 2;
+}
+```
+
+Given pointer_tool.rs already exist
+When adding key_value_tool.rs
+Then use pointer_tool.rs as examples
+And integrate with key_value_service.rs
+
+Implementation Notes
+
+- Place any unit tests at the bottom of the same file as the associated production code
+- Increment patch version of anttp package in Cargo.toml
+- Create a copy of this issue description and save to /spec using the name of this issue as the filename (with lower underscore case, starting with the 5 char padded issue number, e.g. 00001_issue_title.txt)
+- Update unit tests to validate the changes

--- a/src/grpc/key_value_handler.rs
+++ b/src/grpc/key_value_handler.rs
@@ -1,0 +1,71 @@
+use tonic::{Request, Response, Status};
+use actix_web::web::Data;
+use ant_evm::EvmWallet;
+use crate::service::key_value_service::KeyValueService;
+use crate::controller::StoreType;
+use bytes::Bytes;
+
+pub mod key_value_proto {
+    tonic::include_proto!("key_value");
+}
+
+use key_value_proto::key_value_service_server::KeyValueService as KeyValueServiceTrait;
+pub use key_value_proto::key_value_service_server::KeyValueServiceServer;
+use key_value_proto::{CreateKeyValueRequest, GetKeyValueRequest, KeyValueResponse, GetKeyValueBinaryResponse};
+use crate::error::public_data_error::PublicDataError;
+
+pub struct KeyValueHandler {
+    key_value_service: Data<KeyValueService>,
+    evm_wallet: Data<EvmWallet>,
+}
+
+impl KeyValueHandler {
+    pub fn new(key_value_service: Data<KeyValueService>, evm_wallet: Data<EvmWallet>) -> Self {
+        Self { key_value_service, evm_wallet }
+    }
+}
+
+fn to_status(error: PublicDataError) -> Status {
+    Status::internal(error.to_string())
+}
+
+#[tonic::async_trait]
+impl KeyValueServiceTrait for KeyValueHandler {
+    async fn create_key_value(
+        &self,
+        request: Request<CreateKeyValueRequest>,
+    ) -> Result<Response<KeyValueResponse>, Status> {
+        let req = request.into_inner();
+        
+        self.key_value_service.create_key_value_binary(
+            req.bucket.clone(),
+            req.object.clone(),
+            Bytes::from(req.content),
+            self.evm_wallet.get_ref().clone(),
+            StoreType::Network,
+        ).await.map_err(to_status)?;
+
+        Ok(Response::new(KeyValueResponse {
+            bucket: req.bucket,
+            object: req.object,
+        }))
+    }
+
+    async fn get_key_value(
+        &self,
+        request: Request<GetKeyValueRequest>,
+    ) -> Result<Response<GetKeyValueBinaryResponse>, Status> {
+        let req = request.into_inner();
+        
+        let content = self.key_value_service.get_key_value_binary(
+            req.bucket.clone(),
+            req.object.clone(),
+        ).await.map_err(to_status)?;
+
+        Ok(Response::new(GetKeyValueBinaryResponse {
+            bucket: req.bucket,
+            object: req.object,
+            content: content.to_vec(),
+        }))
+    }
+}

--- a/src/grpc/mod.rs
+++ b/src/grpc/mod.rs
@@ -24,3 +24,5 @@ pub mod private_scratchpad_handler;
 pub mod public_scratchpad_handler;
 #[cfg(not(grpc_disabled))]
 pub mod resolver_handler;
+#[cfg(not(grpc_disabled))]
+pub mod key_value_handler;

--- a/src/service/pnr_service.rs
+++ b/src/service/pnr_service.rs
@@ -10,6 +10,7 @@ use ant_protocol::storage::Chunk;
 use autonomi::client::payment::PaymentOption;
 use autonomi::Wallet;
 use bytes::Bytes;
+use mockall::automock;
 
 #[derive(Debug, Clone)]
 pub struct PnrService {
@@ -17,6 +18,7 @@ pub struct PnrService {
     pointer_service: Data<PointerService>
 }
 
+#[automock]
 impl PnrService {
     pub fn new(chunk_caching_client: ChunkCachingClient, pointer_service: Data<PointerService>) -> Self {
         Self { chunk_caching_client, pointer_service }

--- a/src/service/public_data_service.rs
+++ b/src/service/public_data_service.rs
@@ -14,6 +14,7 @@ use crate::error::public_data_error::PublicDataError;
 #[double]
 use crate::service::resolver_service::ResolverService;
 use crate::service::chunk_service::Chunk;
+use mockall::automock;
 
 #[derive(Serialize, Deserialize, ToSchema)]
 pub struct PublicData {
@@ -27,6 +28,7 @@ pub struct PublicDataService {
     resolver_service: ResolverService
 }
 
+#[automock]
 impl PublicDataService {
     pub fn new(public_data_caching_client: PublicDataCachingClient, resolver_service: ResolverService) -> Self {
         Self { public_data_caching_client, resolver_service }

--- a/src/tool/key_value_tool.rs
+++ b/src/tool/key_value_tool.rs
@@ -1,0 +1,71 @@
+#![allow(dead_code)]
+
+use rmcp::{handler::server::{
+    wrapper::Parameters,
+}, schemars, tool, tool_router, ErrorData};
+use rmcp::model::{CallToolResult, ErrorCode};
+use rmcp::schemars::JsonSchema;
+use serde::Deserialize;
+use serde_json::json;
+use crate::error::public_data_error::PublicDataError;
+use crate::tool::McpTool;
+use bytes::Bytes;
+
+#[derive(Debug, Deserialize, JsonSchema)]
+struct McpCreateKeyValueRequest {
+    #[schemars(description = "Bucket name")]
+    bucket: String,
+    #[schemars(description = "Object name")]
+    object: String,
+    #[schemars(description = "Content to store (plain text)")]
+    content: String,
+}
+
+#[derive(Debug, Deserialize, JsonSchema)]
+struct McpGetKeyValueRequest {
+    #[schemars(description = "Bucket name")]
+    bucket: String,
+    #[schemars(description = "Object name")]
+    object: String,
+}
+
+fn to_error_data(error: PublicDataError) -> ErrorData {
+    ErrorData::new(ErrorCode::INTERNAL_ERROR, error.to_string(), None)
+}
+
+#[tool_router(router = key_value_tool_router, vis = "pub")]
+impl McpTool {
+
+    #[tool(description = "Create a new key/value pair in a bucket")]
+    async fn create_key_value(
+        &self,
+        Parameters(McpCreateKeyValueRequest { bucket, object, content }): Parameters<McpCreateKeyValueRequest>,
+    ) -> Result<CallToolResult, ErrorData> {
+        self.key_value_service.create_key_value_binary(
+            bucket.clone(),
+            object.clone(),
+            Bytes::from(content),
+            self.evm_wallet.get_ref().clone(),
+            crate::controller::StoreType::Network,
+        ).await.map_err(to_error_data)?;
+
+        Ok(CallToolResult::structured(json!({
+            "bucket": bucket,
+            "object": object,
+            "status": "created"
+        })))
+    }
+
+    #[tool(description = "Get a key/value pair from a bucket")]
+    async fn get_key_value(
+        &self,
+        Parameters(McpGetKeyValueRequest { bucket, object }): Parameters<McpGetKeyValueRequest>,
+    ) -> Result<CallToolResult, ErrorData> {
+        let content_bytes = self.key_value_service.get_key_value_binary(bucket, object).await.map_err(to_error_data)?;
+        let content = String::from_utf8_lossy(&content_bytes).to_string();
+        
+        Ok(CallToolResult::structured(json!({
+            "content": content
+        })))
+    }
+}

--- a/src/tool/mod.rs
+++ b/src/tool/mod.rs
@@ -10,6 +10,7 @@ use crate::service::scratchpad_service::ScratchpadService;
 use crate::service::archive_service::ArchiveService;
 use crate::service::tarchive_service::TarchiveService;
 use crate::service::resolver_service::ResolverService;
+use crate::service::key_value_service::KeyValueService;
 use actix_web::web::Data;
 use ant_evm::EvmWallet;
 use rmcp::handler::server::tool::ToolRouter;
@@ -30,6 +31,7 @@ pub mod public_scratchpad_tool;
 pub mod private_scratchpad_tool;
 pub mod tarchive_tool;
 pub mod resolver_tool;
+pub mod key_value_tool;
 
 #[derive(Debug, Clone)]
 pub struct McpTool {
@@ -45,6 +47,7 @@ pub struct McpTool {
     scratchpad_service: Data<ScratchpadService>,
     tarchive_service: Data<TarchiveService>,
     resolver_service: Data<ResolverService>,
+    key_value_service: Data<KeyValueService>,
     evm_wallet: Data<EvmWallet>,
     tool_router: ToolRouter<Self>,
 }
@@ -63,6 +66,7 @@ impl McpTool {
         scratchpad_service: Data<ScratchpadService>,
         tarchive_service: Data<TarchiveService>,
         resolver_service: Data<ResolverService>,
+        key_value_service: Data<KeyValueService>,
         evm_wallet: Data<EvmWallet>
     ) -> Self {
         Self {
@@ -78,6 +82,7 @@ impl McpTool {
             scratchpad_service,
             tarchive_service,
             resolver_service,
+            key_value_service,
             evm_wallet,
             tool_router: Self::chunk_tool_router()
                 + Self::pnr_tool_router()
@@ -92,6 +97,7 @@ impl McpTool {
                 + Self::private_scratchpad_tool_router()
                 + Self::tarchive_tool_router()
                 + Self::resolver_tool_router()
+                + Self::key_value_tool_router()
         }
     }
 }


### PR DESCRIPTION
Resolves #176

### Changes
- Added gRPC and MCP tools for key-value endpoints.
- Refactored `KeyValueService` to provide binary and base64 functions.
- Created `proto/key_value.proto` and integrated with gRPC.
- Implemented `KeyValueHandler` for gRPC and `KeyValueTool` for MCP.
- Registered new components in `lib.rs` and relevant `mod.rs` files.
- Incremented patch version in `Cargo.toml` to `0.25.9`.
- Added a spec file for the issue.