### PR TITLE
Improve resolver to validate/sanitise immutable PNRs before resolving (#189)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "anttp"
-version = "0.25.15"
+version = "0.25.16"
 edition = "2024"
 authors = ["Paul Green"]
 description = "AntTP is an HTTP server for the Autonomi Network"

--- a/spec/00189_improve_resolver_to_validate_sanitise_immutable_pnrs_before_resolving.txt
+++ b/spec/00189_improve_resolver_to_validate_sanitise_immutable_pnrs_before_resolving.txt
@@ -1,0 +1,25 @@
+As an AntTP user
+I want to be able safely resolve immutable PNRs
+So that the data immutable PNRs resolve to cannot be changed after it has been created 
+
+Given immutable PNRs should not return any PNR zones with mutable addresses
+When resolving a PNR record with resolve_pointer in pointer_name_resolver.rs
+And iteration == 0 and pointer.target == PointerTarget::ChunkAddress
+Then the resolved PNR record is immutable
+And resolve_pointer should be updated to return an 'isImmutable' boolean in the result
+And pointer_name_resolver.resolve() must then validate that each ResolvedRecord.address is an immutable address
+And if invalid then pointer_name_resolver.resolve() must return 'None'.
+
+Given validate_immutable_addresses function already exists in pnr_service.rs
+When refactoring to make this function accessible across structs
+Then move validate_immutable_addresses to /src/service/mod.rs
+And split it into two (validate_immutable_addresses and validate_immutable_address) to allow individual or multiple address strings to be validated
+And then update pointer_name_resolver.resolve() to call validate_immutable_address to validate addresses
+And then update pnr_service.get_pnr() to call validate_immutable_address to validate addresses.
+
+Implementation Notes
+
+- Place any unit tests at the bottom of the same file as the associated production code
+- Increment patch version of anttp package in Cargo.toml
+- Create a copy of this issue description and save to /spec using the name of this issue as the filename (with lower underscore case, starting with the 5 char padded issue number, e.g. 00001_issue_title.txt)
+- Update unit tests to validate the changes

--- a/src/service/mod.rs
+++ b/src/service/mod.rs
@@ -22,7 +22,11 @@ pub mod key_value_service;
 use crate::config::anttp_config::AntTpConfig;
 use crate::controller::DataKey;
 use crate::error::CreateError;
+use crate::error::pointer_error::PointerError;
+use crate::model::pnr::PnrRecord;
+use ant_protocol::storage::ChunkAddress;
 use autonomi::SecretKey;
+use std::collections::HashMap;
 
 pub fn get_secret_key(ant_tp_config: &AntTpConfig, data_key: DataKey) -> Result<SecretKey, CreateError> {
     match data_key {
@@ -33,4 +37,26 @@ pub fn get_secret_key(ant_tp_config: &AntTpConfig, data_key: DataKey) -> Result<
             Err(e) => Err(CreateError::DataKeyMissing(e.to_string()))
         }
     }
+}
+
+pub fn validate_immutable_address(address: &str) -> Result<(), PointerError> {
+    if address.len() != 64 || ChunkAddress::from_hex(address).is_err() {
+        return Err(PointerError::CreateError(CreateError::InvalidData(format!(
+            "Invalid immutable address: address must be a 64-character hex string, got '{}'",
+            address
+        ))));
+    }
+    Ok(())
+}
+
+pub fn validate_immutable_addresses(records: &HashMap<String, PnrRecord>) -> Result<(), PointerError> {
+    for (key, record) in records {
+        if let Err(e) = validate_immutable_address(&record.address) {
+            return Err(PointerError::CreateError(CreateError::InvalidData(format!(
+                "Invalid immutable address for record '{}': {}",
+                key, e
+            ))));
+        }
+    }
+    Ok(())
 }

--- a/src/service/pnr_service.rs
+++ b/src/service/pnr_service.rs
@@ -10,19 +10,7 @@ use autonomi::client::payment::PaymentOption;
 use autonomi::Wallet;
 use bytes::Bytes;
 
-use std::collections::HashMap;
-
-fn validate_immutable_addresses(records: &HashMap<String, PnrRecord>) -> Result<(), PointerError> {
-    for (key, record) in records {
-        if record.address.len() != 64 || ChunkAddress::from_hex(&record.address).is_err() {
-            return Err(PointerError::CreateError(CreateError::InvalidData(format!(
-                "Invalid immutable address for record '{}': address must be a 64-character hex string",
-                key
-            ))));
-        }
-    }
-    Ok(())
-}
+use crate::service::{validate_immutable_address, validate_immutable_addresses};
 
 #[derive(Debug, Clone)]
 pub struct PnrService {
@@ -184,8 +172,8 @@ impl PnrService {
 
                 if is_immutable {
                     pnr_zone.records.retain(|key, record| {
-                        if record.address.len() != 64 || ChunkAddress::from_hex(&record.address).is_err() {
-                            log::warn!("Removing invalid immutable address for record '{}' in immutable PNR zone '{}'", key, name);
+                        if let Err(e) = validate_immutable_address(&record.address) {
+                            log::warn!("Removing invalid immutable address for record '{}' in immutable PNR zone '{}': {}", key, name, e);
                             false
                         } else {
                             true
@@ -279,6 +267,7 @@ mod tests {
 
     #[test]
     fn test_validate_immutable_addresses_get_pnr() {
+        use super::*;
         let mut records = HashMap::new();
         // Valid 64-char hex address
         let valid_addr = "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef".to_string();
@@ -288,11 +277,7 @@ mod tests {
 
         // Simulate the retain logic in get_pnr
         records.retain(|_, record| {
-            if record.address.len() != 64 || ChunkAddress::from_hex(&record.address).is_err() {
-                false
-            } else {
-                true
-            }
+            validate_immutable_address(&record.address).is_ok()
         });
 
         assert_eq!(records.len(), 1);

--- a/src/service/pointer_name_resolver.rs
+++ b/src/service/pointer_name_resolver.rs
@@ -10,6 +10,7 @@ use crate::client::PointerCachingClient;
 use crate::error::GetError;
 use crate::error::pointer_error::PointerError;
 use crate::model::pnr::PnrZone;
+use crate::service::validate_immutable_address;
 use mockall_double::double;
 
 static PUBLIC_SUFFIX_LIST: Lazy<HashSet<&'static str>> = Lazy::new(|| {
@@ -170,15 +171,28 @@ impl PointerNameResolver {
         debug!("found: zone_name={}, pointer_key={}, public_key={}", zone_name, pointer_key.to_hex(), &pointer_key.public_key().to_hex());
 
         match self.resolve_pointer(&pointer_key.public_key().to_hex(), 0).await.ok() {
-            Some(pointer) => match self.resolve_map(&pointer.target().to_hex(), &sub_name).await {
+            Some((pointer, is_immutable)) => match self.resolve_map(&pointer.target().to_hex(), &sub_name).await {
                 Some(resolved_record) => {
+                    if is_immutable {
+                        if let Err(e) = validate_immutable_address(&resolved_record.address) {
+                            warn!("Removing invalid immutable address for record in immutable PNR zone '{}': {}", name, e);
+                            return None;
+                        }
+                    }
                     // use resolved record TTL to update TTLs for cache
                     self.update_pointer_ttls(&pointer_key.public_key().to_hex(), resolved_record.ttl, 0).await.ok()?;
                     Some(resolved_record) // return map target
                 },
                 None => {
                     if sub_name.is_empty() {
-                        Some(ResolvedRecord::new(pointer.target().to_hex(), self.ttl_default)) // return pointer target if no sub-name
+                        let address = pointer.target().to_hex();
+                        if is_immutable {
+                            if let Err(e) = validate_immutable_address(&address) {
+                                warn!("Removing invalid immutable address for immutable PNR zone '{}': {}", name, e);
+                                return None;
+                            }
+                        }
+                        Some(ResolvedRecord::new(address, self.ttl_default)) // return pointer target if no sub-name
                     } else {
                         None
                     }
@@ -188,7 +202,7 @@ impl PointerNameResolver {
         }
     }
 
-    async fn resolve_pointer(&self, address: &String, iteration: usize) -> Result<Pointer, PointerError> {
+    async fn resolve_pointer(&self, address: &String, iteration: usize) -> Result<(Pointer, bool), PointerError> {
         debug!("resolve_pointer: address={}, iteration={}", address, iteration);
         if iteration > 10 {
             error!("cyclic reference loop - resolve aborting");
@@ -196,9 +210,15 @@ impl PointerNameResolver {
         } else {
             match PointerAddress::from_hex(address) {
                 Ok(pointer_address) => match self.pointer_caching_client.pointer_get(&pointer_address).await {
-                    Ok(pointer) => match pointer.target() {
-                        PointerTarget::ChunkAddress(_) => Ok(pointer),
-                        _ => Box::pin(self.resolve_pointer(&pointer.target().to_hex(), iteration + 1)).await,
+                    Ok(pointer) => {
+                        let is_immutable = iteration == 0 && matches!(pointer.target(), PointerTarget::ChunkAddress(_));
+                        match pointer.target() {
+                            PointerTarget::ChunkAddress(_) => Ok((pointer, is_immutable)),
+                            _ => {
+                                let (p, _) = Box::pin(self.resolve_pointer(&pointer.target().to_hex(), iteration + 1)).await?;
+                                Ok((p, is_immutable))
+                            }
+                        }
                     }
                     Err(_) => Err(PointerError::GetError(GetError::RecordNotFound(format!("Not found: {}", address))))
                 }
@@ -395,7 +415,8 @@ mod tests {
             .returning(|_, _| Ok(Pointer::new(&SecretKey::random(), 0, PointerTarget::ChunkAddress(ChunkAddress::from_hex("a40e045a6fbed33b27039aa8383c9dbf286e19a7265141c2da3085e0c8571527").unwrap()))));
 
         let mut records = HashMap::new();
-        records.insert("sub".to_string(), PnrRecord::new("address123".to_string(), PnrRecordType::A, 100));
+        let valid_address = "b40e045a6fbed33b27039aa8383c9dbf286e19a7265141c2da3085e0c8571527".to_string();
+        records.insert("sub".to_string(), PnrRecord::new(valid_address.clone(), PnrRecordType::A, 100));
         let pnr_zone = PnrZone::new("testname".to_string(), records, None, None);
         let pnr_zone_bytes = serde_json::to_vec(&pnr_zone).unwrap();
 
@@ -408,7 +429,7 @@ mod tests {
 
         assert!(result.is_some());
         let record = result.unwrap();
-        assert_eq!(record.address, "address123");
+        assert_eq!(record.address, valid_address);
         assert_eq!(record.ttl, 100);
     }
 
@@ -548,5 +569,91 @@ mod tests {
         // This should hit the 10 iteration limit
         let result = resolver.resolve_pointer(&addr1.to_hex(), 0).await;
         assert!(result.is_err());
+    }
+
+    #[tokio::test]
+    async fn test_resolve_immutable_validation_fail() {
+        let mut mock_pointer_caching_client = MockPointerCachingClient::default();
+        let mut mock_chunk_caching_client = MockChunkCachingClient::default();
+        
+        // Invalid 64-char hex address (contains 'g')
+        let invalid_addr = "g".repeat(64);
+        let target_chunk_address = ChunkAddress::from_hex("a40e045a6fbed33b27039aa8383c9dbf286e19a7265141c2da3085e0c8571527").unwrap();
+        
+        let pointer = Pointer::new(&SecretKey::random(), 0, PointerTarget::ChunkAddress(target_chunk_address));
+        
+        mock_pointer_caching_client
+            .expect_pointer_get()
+            .returning(move |_| Ok(pointer.clone()));
+
+        // resolve_map returns a record with an invalid address
+        let mut records = HashMap::new();
+        records.insert("".to_string(), PnrRecord::new(invalid_addr, PnrRecordType::A, 60));
+        let pnr_zone = PnrZone::new("testname".to_string(), records, None, None);
+        let chunk = Chunk::new(Bytes::from(serde_json::to_vec(&pnr_zone).unwrap()));
+
+        mock_chunk_caching_client
+            .expect_chunk_get_internal()
+            .returning(move |_| Ok(chunk.clone()));
+
+        let resolver = create_test_resolver(mock_pointer_caching_client, mock_chunk_caching_client);
+        let result = resolver.resolve(&"testname".to_string()).await;
+
+        assert!(result.is_none());
+    }
+
+    #[tokio::test]
+    async fn test_resolve_immutable_direct_validation_fail() {
+        let mut mock_pointer_caching_client = MockPointerCachingClient::default();
+        let mut mock_chunk_caching_client = MockChunkCachingClient::default();
+        
+        let target_chunk_address = ChunkAddress::from_hex("a40e045a6fbed33b27039aa8383c9dbf286e19a7265141c2da3085e0c8571527").unwrap();
+        let sk1 = SecretKey::random();
+        let sk2 = SecretKey::random();
+        
+        // Use fixed resolver SK to match name
+        let resolver_sk = SecretKey::from_hex("55dcbc4624699d219b8ec293339a3b81e68815397f5a502026784d8122d09fce").unwrap();
+        let name = "testname";
+        let expected_pointer_key = Client::register_key_from_name(&resolver_sk, name);
+        let expected_addr = PointerAddress::from_hex(&expected_pointer_key.public_key().to_hex()).unwrap();
+
+        let addr2 = PointerAddress::from_hex(&sk2.public_key().to_hex()).unwrap();
+        
+        let p1 = Pointer::new(&expected_pointer_key, 0, PointerTarget::PointerAddress(addr2));
+        let p2 = Pointer::new(&sk2, 0, PointerTarget::ChunkAddress(target_chunk_address));
+
+        let p1_clone = p1.clone();
+        let p2_clone = p2.clone();
+
+        mock_pointer_caching_client
+            .expect_pointer_get()
+            .returning(move |addr: &PointerAddress| {
+                if addr.to_hex() == expected_addr.to_hex() {
+                    Ok(p1_clone.clone())
+                } else {
+                    Ok(p2_clone.clone())
+                }
+            });
+
+        mock_pointer_caching_client
+            .expect_pointer_update_ttl()
+            .returning(|_, _| Ok(Pointer::new(&SecretKey::random(), 0, PointerTarget::ChunkAddress(ChunkAddress::from_hex("a40e045a6fbed33b27039aa8383c9dbf286e19a7265141c2da3085e0c8571527").unwrap()))));
+
+        // Mock resolve_map to return a record with "invalid" address
+        let mut records = HashMap::new();
+        records.insert("sub".to_string(), PnrRecord::new("invalid".to_string(), PnrRecordType::A, 60));
+        let pnr_zone = PnrZone::new("testname".to_string(), records, None, None);
+        let chunk = Chunk::new(Bytes::from(serde_json::to_vec(&pnr_zone).unwrap()));
+
+        mock_chunk_caching_client
+            .expect_chunk_get_internal()
+            .returning(move |_| Ok(chunk.clone()));
+
+        // If it's NOT immutable (chain of pointers), it should NOT fail validation (because it doesn't run it)
+        let resolver = PointerNameResolver::new(mock_pointer_caching_client, mock_chunk_caching_client, resolver_sk, 3600);
+        let result = resolver.resolve(&"sub.testname".to_string()).await;
+
+        assert!(result.is_some());
+        assert_eq!(result.unwrap().address, "invalid");
     }
 }


### PR DESCRIPTION
Resolves #189.

This PR improves the safety of PNR resolution by validating that immutable PNRs only resolve to immutable addresses.

### Changes:
- Refactored `validate_immutable_addresses` and moved it to `src/service/mod.rs` for broader accessibility.
- Updated `PnrService::get_pnr` and `PnrService::create_immutable_pnr` to use the new validation logic.
- Updated `PointerNameResolver::resolve_pointer` to track and return whether a resolution path leads to an immutable PNR.
- Updated `PointerNameResolver::resolve` to validate resolved addresses if they originate from an immutable PNR.
- Added comprehensive unit tests in `src/service/pointer_name_resolver.rs` to verify validation for both direct and map-based resolutions.
- Incremented patch version in `Cargo.toml`.
- Added a spec file for the issue.